### PR TITLE
84 abstract search list

### DIFF
--- a/src/5-Content/ContentCard.tsx
+++ b/src/5-Content/ContentCard.tsx
@@ -13,10 +13,9 @@ import { BackButton, IconCounter } from '../widgets';
 import { ContentThumbnail } from './content-widgets';
 
 
-
 interface ContentCardProps {
   item:ContentListItem;
-  onPress?:(item:ContentListItem) => void;
+  onPress?:(id:number, item:ContentListItem) => void;
   style?:StyleProp<ViewStyle>;
   onKeywordPress?:(keyword:string) => void;
 }
@@ -30,7 +29,7 @@ const ContentCard: React.FC<ContentCardProps> = ({ item, onPress, style, onKeywo
   return (
     <View style={StyleSheet.flatten([styles.card, style])} >
         <ContentThumbnail imageUri={item.image} contentSource={item.source} onPress={() => {
-          if(onPress) onPress(item);
+          if(onPress) onPress(item.contentID, item);
           if(item.url && item.url.length > 5) { //Already filtered by MOBILE_CONTENT_SUPPORTED_SOURCES
             if(item.source === ContentSourceEnum.YOUTUBE) setShowYouTube(true);
             else openInAppBrowser(item.url);
@@ -51,7 +50,7 @@ const ContentCard: React.FC<ContentCardProps> = ({ item, onPress, style, onKeywo
               <Text style={styles.detailText} numberOfLines={1} ellipsizeMode='tail' >{makeDisplayText(item.source)}</Text>
               <Text style={styles.verticalDivider}>|</Text>
               <View style={styles.tagContainer}>
-                {item.keywordList.map((keyword, index) => (
+                {[...(item.keywordList || [])].map((keyword, index) => (
                   <TouchableOpacity key={`${keyword}-${index}`} onPress={() => onKeywordPress && onKeywordPress(keyword)}>
                     <Text style={styles.tag}>#{makeDisplayText(keyword)}</Text>
                   </TouchableOpacity>
@@ -134,7 +133,6 @@ const styles = StyleSheet.create({
   ...theme,
   contentCardTitle: {
     ...theme.title,
-    fontSize: 20,
     color: COLORS.white
   },
   card: {

--- a/src/5-Content/ContentDisplay.tsx
+++ b/src/5-Content/ContentDisplay.tsx
@@ -1,18 +1,16 @@
 import axios, { AxiosError } from 'axios';
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, View, ScrollView, TouchableOpacity, TextInput } from 'react-native';
 import { RootState } from '../redux-store';
-import Ionicons from 'react-native-vector-icons/Ionicons';
 import { DOMAIN } from '@env';
 import { useAppSelector } from '../TypesAndInterfaces/hooks';
-import theme, { COLORS } from '../theme';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ServerErrorResponse } from '../TypesAndInterfaces/config-sync/api-type-sync/toast-types';
 import ToastQueueManager from '../utilities/ToastQueueManager';
 import { ContentListItem } from '../TypesAndInterfaces/config-sync/api-type-sync/content-types';
 import { ContentSourceEnum, ContentTypeEnum, MOBILE_CONTENT_SUPPORTED_SOURCES } from '../TypesAndInterfaces/config-sync/input-config-sync/content-field-config';
-import ContentCard from './ContentCard';
-import { Tab_Selector } from '../widgets';
+import SearchList from '../Widgets/SearchList/SearchList';
+import { SearchFilterIdentifiable, SearchListKey, SearchListValue } from '../Widgets/SearchList/searchList-types';
+import { ListItemTypesEnum, SearchType } from '../TypesAndInterfaces/config-sync/input-config-sync/search-config';
 
 
 /************************
@@ -26,10 +24,7 @@ const ContentDisplay = (props:{callback?:(() => void), navigation:NativeStackNav
     const jwt = useAppSelector((state:RootState) => state.account.jwt);
     const userID = useAppSelector((state:RootState) => state.account.userID);
 
-    const [contentOriginalList, setContentOriginalList] = useState<ContentListItem[]>([]);
     const [contentList, setContentList] = useState<ContentListItem[]>([]); //Apply filtering locally
-    const [filterType, setFilterType] = useState<ContentTypeEnum | undefined>(undefined);
-    const [searchTerm, setSearchTerm] = useState<string | undefined>(undefined);
 
     useEffect(() => {
         axios.get(`${DOMAIN}/api/user/`+ userID + '/content-list', { headers: { jwt }})
@@ -37,96 +32,25 @@ const ContentDisplay = (props:{callback?:(() => void), navigation:NativeStackNav
           const list:ContentListItem[] = [...response.data]
             .filter((content:ContentListItem) => MOBILE_CONTENT_SUPPORTED_SOURCES.includes(content.source as ContentSourceEnum));
           setContentList(list) ;
-          setContentOriginalList(list);
         }) //Custom strings won't match
         .catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));        
     }, []);
-
-    useEffect(() => {
-        setContentList((filterType !== undefined) ? contentOriginalList.filter(item => item.type === filterType) : contentOriginalList);
-    }, [contentOriginalList, filterType]);
   
     
       return (
-        <View style={styles.contentPage}>
-          <View style={styles.searchHeader} >
-              {(searchTerm === undefined) ?
-                <Tab_Selector
-                    optionList={MOBILE_SUPPORTED_CONTENT_TYPES}
-                    defaultIndex={(filterType !== undefined) ? MOBILE_SUPPORTED_CONTENT_TYPES.indexOf(filterType) : undefined}
-                    onSelect={(item:string, index:number) => setFilterType(MOBILE_SUPPORTED_CONTENT_TYPES[index])}
-                    onDeselect={() => setFilterType(undefined)}
-                    isHeader={true}
-                    style={styles.filterContainer}
-                  />
-                : <TextInput
-                    style={styles.searchInput}
-                    placeholder={'Search...'}
-                    placeholderTextColor={COLORS.accent}
-                    value={searchTerm}
-                    onChangeText={setSearchTerm}
-                  />
-              }
-              <TouchableOpacity style={styles.searchIcon}
-                onPress={() => setSearchTerm((searchTerm === undefined) ? '' : undefined)}
-              >
-                <Ionicons 
-                    name='search-outline'
-                    color={COLORS.white}
-                    size={theme.header.fontSize}
-                    onPress={() => setSearchTerm((searchTerm === undefined) ? '' : undefined)}
-                />
-              </TouchableOpacity>
-          </View>
-          <ScrollView >
-            {[...contentList].map((content: ContentListItem, index: number) => (
-              <ContentCard key={`content-${content.contentID}-${index}`} item={content} />
-            ))}
-        </ScrollView>
-        </View>
+        <SearchList
+                key={'content-page'}
+                filterOptions={MOBILE_SUPPORTED_CONTENT_TYPES}
+                onFilter={(listValue:SearchListValue, appliedFilter?:SearchFilterIdentifiable) => ((listValue.displayItem as ContentListItem).type === ContentTypeEnum[appliedFilter?.filterOption as keyof typeof ContentTypeEnum])}
+                displayMap={new Map([
+                        [
+                            new SearchListKey({displayTitle:'Content', searchType: SearchType.CONTENT_ARCHIVE }),
+                            [...contentList].map((content) => new SearchListValue({displayType: ListItemTypesEnum.CONTENT_ARCHIVE, displayItem: content }))
+                        ],
+                    ])}
+            />
       );
     };
     
-
-  /***********************
-   * CONTENT PAGE STYLES *
-   ***********************/
-
-    const styles = StyleSheet.create({
-      ...theme,
-      contentPage: {
-        backgroundColor: COLORS.black,
-        flex: 1,
-        width: '100%'
-      },
-      searchHeader: {
-        width: '100%',
-        height: theme.header.fontSize + 15,
-        flexDirection: 'row',
-        justifyContent: 'center',
-        alignItems: 'flex-end',
-        paddingHorizontal: 5,
-        paddingVertical: 10,
-      },
-      searchIcon: {
-        position: 'absolute',
-        left: 5,
-        top: 5
-      },
-      searchInput: {
-        width: '100%',
-        paddingLeft: theme.header.fontSize + 10,
-        paddingBottom: 2,
-
-        ...theme.title,
-        color: COLORS.white,
-        fontSize: 20,
-        borderBottomWidth: 1,
-        borderColor: COLORS.accent
-      },
-      filterContainer: {
-        marginHorizontal: theme.header.fontSize + 10,
-      }
-    });
 
 export default ContentDisplay;

--- a/src/5-Content/ContentDisplay.tsx
+++ b/src/5-Content/ContentDisplay.tsx
@@ -21,8 +21,8 @@ const MOBILE_SUPPORTED_CONTENT_TYPES = [ContentTypeEnum.ARTICLE, ContentTypeEnum
 
 const ContentDisplay = (props:{callback?:(() => void), navigation:NativeStackNavigationProp<any, string, undefined>}):JSX.Element => {
 
-    const jwt = useAppSelector((state:RootState) => state.account.jwt);
-    const userID = useAppSelector((state:RootState) => state.account.userID);
+    const jwt:string = useAppSelector((state:RootState) => state.account.jwt);
+    const userID:number = useAppSelector((state:RootState) => state.account.userID);
 
     const [contentList, setContentList] = useState<ContentListItem[]>([]); //Apply filtering locally
 
@@ -31,7 +31,7 @@ const ContentDisplay = (props:{callback?:(() => void), navigation:NativeStackNav
         .then((response:{data:ContentListItem[]}) => {
           const list:ContentListItem[] = [...response.data]
             .filter((content:ContentListItem) => MOBILE_CONTENT_SUPPORTED_SOURCES.includes(content.source as ContentSourceEnum));
-          setContentList(list) ;
+          setContentList(list);
         }) //Custom strings won't match
         .catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));        
     }, []);

--- a/src/5-Content/content-widgets.tsx
+++ b/src/5-Content/content-widgets.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect } from 'react';
 import { Image, StyleSheet, ImageStyle, ImageSourcePropType, Dimensions, TouchableOpacity } from 'react-native';
 import { ContentSourceEnum } from '../TypesAndInterfaces/config-sync/input-config-sync/content-field-config';
 
@@ -27,14 +27,21 @@ export const ContentThumbnail = (props:{imageUri:string|undefined, contentSource
         setAspectRatio(width / height);
     };
 
-    useEffect(() => {
+    useLayoutEffect(() => {
+        let isMounted = true;
+
+        const setImageAspect = (width:number, height:number) => {
+            if (isMounted)
+                setAspectRatio(width / height);
+        };
+
         if (props.imageUri) {
             setImage({ uri: props.imageUri });
-            Image.getSize(props.imageUri, (width, height) => {
-                setAspectRatio(width / height);
-            }, setDefaultThumbnail);
+            Image.getSize(props.imageUri, setImageAspect, setDefaultThumbnail);
         } else
             setDefaultThumbnail();
+
+        return () => { isMounted = false; }
     }, [props.imageUri, props.contentSource]);
 
     const styles = StyleSheet.create({

--- a/src/TypesAndInterfaces/config-sync/input-config-sync/content-field-config.ts
+++ b/src/TypesAndInterfaces/config-sync/input-config-sync/content-field-config.ts
@@ -68,7 +68,7 @@ export enum ContentSearchRefineEnum {
 * UTILITY METHODS *
 *******************/
 export const extractYouTubeVideoId = (url:string):string|undefined => {
-    const match = url.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+    const match = url?.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
     return match ? match[1] : undefined;
   };
 

--- a/src/Widgets/SearchList/SearchList.tsx
+++ b/src/Widgets/SearchList/SearchList.tsx
@@ -1,0 +1,360 @@
+import axios, { AxiosError } from 'axios';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { View, Text, TextInput, StyleSheet, Animated, NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+import { SearchFilterIdentifiable, SearchListKey, SearchListValue} from './searchList-types';
+import { ContentListItem } from '../../TypesAndInterfaces/config-sync/api-type-sync/content-types';
+import SearchDetail, { SearchTypeInfo, DisplayItemType, SearchType, ListItemTypesEnum, SEARCH_MIN_CHARS } from '../../TypesAndInterfaces/config-sync/input-config-sync/search-config';
+import { useAppSelector } from '../../TypesAndInterfaces/hooks';
+import { ServerErrorResponse } from '../../TypesAndInterfaces/config-sync/api-type-sync/toast-types';
+import ToastQueueManager from '../../utilities/ToastQueueManager';
+import { Page_Title, Raised_Button, Tab_Selector } from '../../widgets';
+import ContentCard from '../../5-Content/ContentCard';
+import theme, { COLORS } from '../../theme';
+import Ionicons from 'react-native-vector-icons/Ionicons';
+import { DOMAIN } from '@env';
+import { ContentSearchFilterEnum } from '../../TypesAndInterfaces/config-sync/input-config-sync/content-field-config';
+import debounce from '../../utilities/debounceHook';
+
+
+/*********************************************************************************
+ *                DYNAMIC SEARCH & DISPLAY LIST                                  *
+ *  Full Page List View Dynamically Populates base on ListItemType               *
+ *  Handles Relevant Searching, Filtering, toggling multi List Display           *
+ *  Callbacks available of onPress, action buttons, and filter by sub properties *
+ *********************************************************************************/
+const SearchList = ({...props}:{key:any, pageTitle?:string, displayMap:Map<SearchListKey, SearchListValue[]>, filterOptions?:string[], onFilter?:(listValue:SearchListValue, appliedFilter?:SearchFilterIdentifiable) => boolean}) => {
+    const jwt:string = useAppSelector((state) => state.account.jwt);
+
+    /* Properties for Auto-hiding Sticky Header Handling */
+    const scrollPosition = useRef<Animated.Value>(new Animated.Value(0)).current;
+    const lastScrollPosition = useRef(0);
+    const [isScrollingDown, setIsScrollingDown] = useState(false);
+    const [headerHeight, setHeaderHeight] = useState(0);
+    const headerRef = useRef<View>(null);
+
+    /* Search List State */
+    const [displayList, setDisplayList] = useState<SearchListValue[]>([]);
+    const [selectedKey, setSelectedKey] = useState<SearchListKey>(new SearchListKey({displayTitle: 'Default'}));
+    const [searchCacheMap, setSearchCacheMap] = useState<Map<string, SearchListValue>|undefined>(undefined); //Quick pairing for accurate button options
+    const [appliedFilter, setAppliedFilter] = useState<SearchFilterIdentifiable | undefined>(undefined);
+    const [searchTerm, setSearchTerm] = useState<string|undefined>(undefined);
+    const [lastEmptySearchTerm, setLastEmptySearchTerm] = useState<string|undefined>(undefined); //Efficiently detect failed sequential searches
+
+    /* Utility displayMap Accessors */
+    const getKey = (keyTitle:string = selectedKey.displayTitle):SearchListKey => Array.from(props.displayMap.keys()).find((k) => k.displayTitle === keyTitle) || new SearchListKey({displayTitle: 'Default'});
+    const getList = (keyTitle:string = selectedKey.displayTitle):SearchListValue[] => props.displayMap.get(getKey(keyTitle)) || [];
+    const getSearchDetail = (searchType:SearchType = selectedKey.searchType):SearchTypeInfo<DisplayItemType> => SearchDetail[selectedKey.searchType];
+
+    const getListTitles = (filterEmptyLists:boolean = false):string[] => Array.from(props.displayMap.entries())
+        .filter(([key, valueList]:[SearchListKey, SearchListValue[]]) => !filterEmptyLists || valueList.length > 0)
+        .map(([key, valueList]:[SearchListKey, SearchListValue[]]) => key.displayTitle);
+
+    const getKeyIndex = (keyTitle:string = selectedKey.displayTitle):number|undefined => {
+        const index = Array.from(props.displayMap.keys()).findIndex((k) => k.displayTitle === keyTitle);
+        return index !== -1 ? index : undefined;
+    };
+    
+    const getFilterIndex = (filterOption?:string): number | undefined => {
+        if (appliedFilter === undefined || props.filterOptions === undefined) return undefined;
+        else if(filterOption === undefined) filterOption = appliedFilter.filterOption;
+        const index = props.filterOptions.findIndex((option) => option === filterOption);
+        return index !== -1 ? index : undefined;
+    };
+
+    /* Setup Default List */
+    //Note: Currently not supporting multiple list types like portal
+    const getDefaultDisplayList = ():SearchListValue[] => {
+        const defaultList:SearchListValue[] = [];
+        const firstEntry:[SearchListKey, SearchListValue[]] | undefined = Array.from(props.displayMap.entries()).find(([key, itemList]) => itemList.length > 0);
+        if(firstEntry !== undefined) {
+            defaultList.push(...firstEntry[1]);
+            setSelectedKey(firstEntry[0] || new SearchListKey({displayTitle: 'Default'}));
+        }
+        return defaultList;
+    }
+
+    useLayoutEffect(() => {        
+        setDisplayList(getDefaultDisplayList());
+    },[props.displayMap]);
+
+
+    /**************************************************************
+     *                          SERVER SEARCH
+     * Use Cache list of current items to optimize button settings
+     * *************************************************************/
+    const executeSearch = async(value:string|undefined = searchTerm) => { //copy over primary/alternative button settings (optimize buttons)
+        if(value === undefined || value.length === 0 || selectedKey.searchType === undefined 
+            || selectedKey.searchType === SearchType.NONE || (lastEmptySearchTerm && value.includes(lastEmptySearchTerm))) {
+                ToastQueueManager.show({message: 'Searching Unavailable'});
+                return;
+        }
+
+        const selectedDetail:SearchTypeInfo<DisplayItemType> = getSearchDetail();
+        const params:{[key: string]:string} = { search:value };
+        if(selectedDetail.searchFilterList.length > 0 && selectedKey.searchFilter !== undefined) params['filter'] = ContentSearchFilterEnum.MOBILE;
+        if(process.env.SEARCH_IGNORE_CACHE === 'true') params['ignoreCache'] = 'true';
+
+        await axios.get(`${DOMAIN}` + selectedDetail.route, { headers: { jwt }, params} )
+            .then((response:{status:number, data:DisplayItemType[]}) => {
+                //No matches found
+                if(response.status === 205) {
+                    setDisplayList([]);
+                    setLastEmptySearchTerm(value);
+                    ToastQueueManager.show({message: 'No Matches Found'});
+                    return;
+                }
+
+                const cacheMap:Map<string, SearchListValue> = searchCacheMap || assembleSearchButtonCache();
+                const resultList:SearchListValue[] = [];  
+                const displayType:ListItemTypesEnum = selectedDetail.itemType;
+
+                Array.from(response.data).forEach((displayItem) => {
+                    const itemID:number = selectedDetail.getID(displayItem);
+                    let listValueItem:SearchListValue|undefined = cacheMap.get(`${selectedKey.searchType}-${itemID}`); //First attempt local cache
+
+                    if(listValueItem === undefined) {
+                        listValueItem = new SearchListValue({displayType, displayItem: displayItem, 
+                            onClick: selectedKey.onSearchClick,
+                            primaryButtonText: selectedKey.searchPrimaryButtonText,
+                            onPrimaryButtonCallback: selectedKey.onSearchPrimaryButtonCallback,
+                            alternativeButtonText: selectedKey.searchAlternativeButtonText,
+                            onAlternativeButtonCallback: selectedKey.onSearchAlternativeButtonCallback
+                        });
+                    }
+                    resultList.push(listValueItem);
+                });
+
+                //Attempt to apply current Filter, no matches reset filter, list could still be empty
+                const applyActiveFilter:boolean = (appliedFilter !== undefined) && (props.onFilter !== undefined)
+                    && resultList.some((item:SearchListValue) => props.onFilter && props.onFilter(item, appliedFilter));
+
+                if(applyActiveFilter)
+                    setDisplayList(resultList.filter((item:SearchListValue) => props.onFilter && props.onFilter(item, appliedFilter)));
+                else {
+                    setDisplayList(resultList);
+                    setAppliedFilter(undefined);
+                }
+
+            }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
+    }
+
+    
+    //Save Map as: 'type-id' : SearchListValue = CIRCLE-1 : {...}
+    const assembleSearchButtonCache = ():Map<string, SearchListValue> => { 
+        const selectedDetail:SearchTypeInfo<DisplayItemType> = getSearchDetail();
+        const cacheMap = new Map();
+        Array.from(props.displayMap.values()).reverse().flatMap(list => list).forEach((item:SearchListValue) => {
+            const itemID:number = selectedDetail.getID(item.displayItem);
+            if(itemID > 0)
+                cacheMap.set(`${item.displayType}-${selectedDetail.getID(item.displayItem)}`, item);
+        });
+        setSearchCacheMap(cacheMap);
+        return cacheMap;
+    }
+
+
+    /*****************************************
+     *   APPLY FILTER to current displayList *
+     * props.onFilter determines filter      *
+     * ***************************************/
+    const onApplyFilter = (filterOption:string) => {
+        if(!props.filterOptions || !props.filterOptions.includes(filterOption) || (displayList.length === 0)) {
+            setAppliedFilter(undefined);
+            ToastQueueManager.show({message: 'Filter Unavailable'});
+            return;
+        }
+        const currentList:SearchListValue[] = appliedFilter ? getList() : displayList;
+        setDisplayList(currentList.filter((item:SearchListValue) => !props.onFilter || props.onFilter(item, appliedFilter)));
+        setAppliedFilter({filterOption, listKeyTitle: selectedKey.displayTitle});
+    }
+
+
+    /******************
+     * Input Handlers *
+     ******************/
+    //Delay Search until typing pauses
+    const onExecuteSearch = useCallback(debounce(executeSearch, 1500), [searchTerm]);
+
+    const onSearchInput = (value:string = '') => {
+        setSearchTerm(value);
+        if(value.length >= SEARCH_MIN_CHARS && (searchTerm?.trim() !== value.trim()))
+            onExecuteSearch(value);
+    }
+
+    const onListSelection = (keyTitle:string) => {
+        setSelectedKey(getKey(keyTitle));
+        setDisplayList(getList(keyTitle));
+        setAppliedFilter(undefined);
+        setSearchTerm(undefined);
+    }
+
+    const resetPage = (keyTitle?: string):void => {
+        setSelectedKey(getKey(keyTitle));
+        setDisplayList((!keyTitle || (keyTitle.length === 0)) ? getDefaultDisplayList() : getList(keyTitle));
+        setAppliedFilter(undefined);
+        setSearchTerm(undefined);
+        setSearchCacheMap(undefined);
+        ToastQueueManager.show({message: 'Page Reset'});
+    };
+
+
+    /*******************************************************
+     *       AUTO-HIDING STICKY HEADER HANDLING            *
+     * Hides on scroll down, reappears on slight scroll up *
+     *******************************************************/
+    const headerTranslate = scrollPosition.interpolate({
+        inputRange: [0, headerHeight],
+        outputRange: [0, -headerHeight],
+        extrapolate: 'clamp',
+    });
+
+    const onScroll = Animated.event(
+        [{ nativeEvent: { contentOffset: { y: scrollPosition } } }],
+        {
+            useNativeDriver: true,
+            listener: (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+                const currentY = event.nativeEvent.contentOffset.y;
+                setIsScrollingDown(currentY > lastScrollPosition.current);
+                lastScrollPosition.current = currentY;
+            },
+        }
+    );
+
+    return (
+        <View style={styles.container}>
+            <Animated.View ref={headerRef} 
+                style={[ styles.headerContainer, { transform: [{ translateY: isScrollingDown ? headerTranslate : 0 }] } ]}
+                onLayout={(event) => setHeaderHeight(event.nativeEvent.layout.height)}
+            >
+
+                {(searchTerm !== undefined) ?
+                    <TextInput
+                        style={styles.searchInput}
+                        placeholder={'Search...'}
+                        placeholderTextColor={COLORS.accent}
+                        value={searchTerm}
+                        onChangeText={onSearchInput}
+                        onSubmitEditing={() => executeSearch()}
+                    />
+                : (props.pageTitle !== undefined) &&
+                    <Page_Title title={props.pageTitle} containerStyle={styles.titleContainer} />
+                }
+                { (getListTitles().length > 1) &&
+                    <Tab_Selector
+                        optionList={getListTitles()}
+                        defaultIndex={getKeyIndex()}
+                        onSelect={(title:string, index:number) => onListSelection(title)}
+                        containerStyle={styles.tabHeaderContainer}
+                        textStyle={styles.title}
+                    />
+                }
+                { (props.filterOptions) &&
+                    <Tab_Selector
+                        optionList={props.filterOptions}
+                        defaultIndex={getFilterIndex()}
+                        onSelect={(item:string, index:number) => onApplyFilter(item)}
+                        onDeselect={() => setDisplayList(getList())}
+                        containerStyle={styles.tabHeaderContainer}
+                        textStyle={styles.title}
+                    />
+                }
+                <Ionicons 
+                    name='search-outline'
+                    color={COLORS.accent}
+                    size={theme.title.fontSize}
+                    style={styles.searchIcon}
+                    onPress={() => setSearchTerm((searchTerm === undefined) ? '' : undefined)}
+                />
+            </Animated.View>
+
+            {(displayList.length === 0) ?
+                <View style={styles.resetWrapper} >
+                    <Raised_Button 
+                        text={`Reset Page`}
+                        onPress={() => resetPage()}
+                    />
+                </View>
+
+            : <Animated.ScrollView style={[styles.displayScrollList, { paddingTop: headerHeight }]} onScroll={onScroll} scrollEventThrottle={16} >
+                {displayList.map((item: SearchListValue, index) => (
+                    <React.Fragment key={`${props.key}+${index}`}>
+                        { item.displayType === ListItemTypesEnum.CONTENT_ARCHIVE ? (
+                            <ContentCard {...item} item={item.displayItem as ContentListItem} onPress={item.onClick} />
+                        ) : (
+                            <Text>ERROR</Text>
+                        )}
+                    </React.Fragment>
+                ))}
+            </Animated.ScrollView>
+            }
+        </View>
+    );
+}
+
+export default SearchList;
+
+
+const styles = StyleSheet.create({
+    ...theme,
+    container: {
+        backgroundColor: COLORS.black,
+        flex: 1,
+    },
+    headerContainer: {
+        position: 'absolute',
+        zIndex: 1,
+        top: 0,
+        left: 0,
+        right: 0,
+        width: '100%',
+        backgroundColor: COLORS.black,
+
+        flexDirection: 'column',
+        justifyContent: 'space-around',
+        alignItems: 'center',
+
+        paddingHorizontal: 5,
+        paddingVertical: 15,
+    },  
+    searchHeaderField: {
+        flex: 1,
+        paddingHorizontal: theme.header.fontSize + 10,
+        marginBottom: theme.header.fontSize / 4,
+    },
+    searchInput: {
+        width: '100%',
+        paddingLeft: theme.header.fontSize + 10,
+        marginBottom: theme.header.fontSize / 4,
+
+        ...theme.text,
+        color: COLORS.white,
+        borderBottomWidth: 1,
+        borderColor: COLORS.accent
+    },  
+    titleContainer: {
+        padding: 0,
+        marginHorizontal: theme.header.fontSize + 10,
+        marginBottom: theme.header.fontSize / 4,
+     },
+    searchHeaderSearch: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    tabHeaderContainer: {
+        marginBottom: theme.title.fontSize / 4,
+    },
+    searchIcon: {
+        position: 'absolute',
+        zIndex: 2,
+        left: 5,
+        top: 10,
+    },
+    displayScrollList: {
+        flex: 1,
+    },
+    resetWrapper: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'center',
+    }
+});

--- a/src/Widgets/SearchList/searchList-types.tsx
+++ b/src/Widgets/SearchList/searchList-types.tsx
@@ -14,18 +14,18 @@ export class SearchListKey {
     displayTitle:string;
     searchType:SearchType;
     searchFilter?:string; //Matches SearchTypeInfo.searchFilterList
-    onSearchClick?:(id:number, item:DisplayItemType)=>void;
+    onSearchPress?:(id:number, item:DisplayItemType)=>void;
     searchPrimaryButtonText?:string;
     onSearchPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void;
     searchAlternativeButtonText?:string;
     onSearchAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void;
 
-    constructor({...props}:{displayTitle:string, searchType?:SearchType, searchFilter?:string, onSearchClick?:(id:number, item:DisplayItemType)=>void, 
+    constructor({...props}:{displayTitle:string, searchType?:SearchType, searchFilter?:string, onSearchPress?:(id:number, item:DisplayItemType)=>void, 
         searchPrimaryButtonText?:string, onSearchPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void, searchAlternativeButtonText?:string, onSearchAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void}) {
         this.displayTitle = props.displayTitle;
         this.searchType = props.searchType || SearchType.NONE;
         this.searchFilter = props.searchFilter;
-        this.onSearchClick = props.onSearchClick;
+        this.onSearchPress = props.onSearchPress;
         this.searchPrimaryButtonText = props.searchPrimaryButtonText;
         this.onSearchPrimaryButtonCallback = props.onSearchPrimaryButtonCallback;
         this.searchAlternativeButtonText = props.searchAlternativeButtonText;
@@ -36,19 +36,19 @@ export class SearchListKey {
 export class SearchListValue {         //Every list item is wrapped in this view | allows list items of different types
     displayType:ListItemTypesEnum;
     displayItem:DisplayItemType;
-    onClick?:(id:number, item:DisplayItemType)=>void;
+    onPress?:(id:number, item:DisplayItemType)=>void;
     primaryButtonText?:string;
     onPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void;
     alternativeButtonText?:string;
     onAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void;
     
 
-    constructor({...props}:{displayType:ListItemTypesEnum, displayItem:DisplayItemType, onClick?:(id:number, item:DisplayItemType)=>void, 
+    constructor({...props}:{displayType:ListItemTypesEnum, displayItem:DisplayItemType, onPress?:(id:number, item:DisplayItemType)=>void, 
         primaryButtonText?:string, onPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void, alternativeButtonText?:string, onAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void}) {
 
         this.displayType = props.displayType;
         this.displayItem = props.displayItem;
-        this.onClick = props.onClick;
+        this.onPress = props.onPress;
         this.primaryButtonText = props.primaryButtonText;
         this.onPrimaryButtonCallback = props.onPrimaryButtonCallback;
         this.alternativeButtonText = props.alternativeButtonText;

--- a/src/Widgets/SearchList/searchList-types.tsx
+++ b/src/Widgets/SearchList/searchList-types.tsx
@@ -1,0 +1,57 @@
+import { SearchType, DisplayItemType, ListItemTypesEnum } from "../../TypesAndInterfaces/config-sync/input-config-sync/search-config";
+
+
+/********************
+ * SEARCH LIST TYPES
+ * ******************/
+
+export type SearchFilterIdentifiable = {
+    filterOption: string; 
+    listKeyTitle: string;
+};
+
+export class SearchListKey { 
+    displayTitle:string;
+    searchType:SearchType;
+    searchFilter?:string; //Matches SearchTypeInfo.searchFilterList
+    onSearchClick?:(id:number, item:DisplayItemType)=>void;
+    searchPrimaryButtonText?:string;
+    onSearchPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void;
+    searchAlternativeButtonText?:string;
+    onSearchAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void;
+
+    constructor({...props}:{displayTitle:string, searchType?:SearchType, searchFilter?:string, onSearchClick?:(id:number, item:DisplayItemType)=>void, 
+        searchPrimaryButtonText?:string, onSearchPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void, searchAlternativeButtonText?:string, onSearchAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void}) {
+        this.displayTitle = props.displayTitle;
+        this.searchType = props.searchType || SearchType.NONE;
+        this.searchFilter = props.searchFilter;
+        this.onSearchClick = props.onSearchClick;
+        this.searchPrimaryButtonText = props.searchPrimaryButtonText;
+        this.onSearchPrimaryButtonCallback = props.onSearchPrimaryButtonCallback;
+        this.searchAlternativeButtonText = props.searchAlternativeButtonText;
+        this.onSearchAlternativeButtonCallback = props.onSearchAlternativeButtonCallback;
+    }
+}
+
+export class SearchListValue {         //Every list item is wrapped in this view | allows list items of different types
+    displayType:ListItemTypesEnum;
+    displayItem:DisplayItemType;
+    onClick?:(id:number, item:DisplayItemType)=>void;
+    primaryButtonText?:string;
+    onPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void;
+    alternativeButtonText?:string;
+    onAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void;
+    
+
+    constructor({...props}:{displayType:ListItemTypesEnum, displayItem:DisplayItemType, onClick?:(id:number, item:DisplayItemType)=>void, 
+        primaryButtonText?:string, onPrimaryButtonCallback?:(id:number, item:DisplayItemType)=>void, alternativeButtonText?:string, onAlternativeButtonCallback?:(id:number, item:DisplayItemType)=>void}) {
+
+        this.displayType = props.displayType;
+        this.displayItem = props.displayItem;
+        this.onClick = props.onClick;
+        this.primaryButtonText = props.primaryButtonText;
+        this.onPrimaryButtonCallback = props.onPrimaryButtonCallback;
+        this.alternativeButtonText = props.alternativeButtonText;
+        this.onAlternativeButtonCallback = props.onAlternativeButtonCallback;
+    }
+}

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -39,7 +39,6 @@ export default StyleSheet.create({
     },
     title: {
         fontFamily: FONTS.title,
-        //color: COLORS.white,
         color: COLORS.primary,
         fontSize: FONT_SIZES.L,
         fontWeight: '700',

--- a/src/utilities/debounceHook.ts
+++ b/src/utilities/debounceHook.ts
@@ -1,0 +1,19 @@
+
+/* Listener for detecting delay in typing */
+
+//Example Usage: Detecting pause before searching in SearchList
+//useCallback(debounce(executeSearch, 500), [searchTerm])
+
+const debounce = (callback:Function, delay: number) => {
+    let timeoutId: NodeJS.Timeout;
+    return (...args: any[]) => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+      timeoutId = setTimeout(() => {
+        callback(...args);
+      }, delay);
+    };
+  };
+
+  export default debounce;

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -109,9 +109,12 @@ export const Tab_Selector = (props:{optionList:string[], defaultIndex:number|und
         filterContainer: {
             flexDirection: 'row',
             padding: 0,
-            borderTopWidth: 1,
-            borderBottomWidth: 1,
-            borderColor: (props.textStyle?.color) ? props.textStyle.color : COLORS.accent,
+
+            borderWidth: 1,
+            borderColor: COLORS.grayDark,
+            borderRadius: (props.textStyle?.fontSize ?? theme.text.fontSize) / 2,
+            overflow: 'hidden',
+
             ...props.containerStyle,
           },
           filterSelected: {
@@ -474,7 +477,7 @@ export const SelectSlider = (props:{minValue:number, maxValue:number, defaultVal
     )
 }
 
-export const ProfileImage = (props:{style?:ImageStyle}):JSX.Element => {
+export const ProfileImage = (props:{style?:ImageStyle, onPress?:() => void}):JSX.Element => {
     const userProfileImage = useAppSelector((state: RootState) => state.account.userProfile.image);
     const DEFAULT_PROFILE_ICON = require("../assets/profile-icon-blue.png");
 
@@ -491,10 +494,9 @@ export const ProfileImage = (props:{style?:ImageStyle}):JSX.Element => {
     })
 
     return (
-        <>
+        <TouchableOpacity onPress={() => props.onPress && props.onPress()}>
             <Image source={requestorImage} style={styles.profileImage}></Image>
-        </>
-
+        </TouchableOpacity>
     );
 }
 

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -281,7 +281,7 @@ export const DatePicker = (props:{validationLabel?:string, buttonStyle?:ViewStyl
 export const Dropdown_Select = (props:{validationLabel?:string, saveKey?:boolean, label?:string, setSelected:((val:string) => void), data: SelectListItem[], placeholder?:string, boxStyle?:ViewStyle, validationStyle?:TextStyle, labelStyle?:TextStyle, defaultOption?:SelectListItem }):JSX.Element => {
     const styles = StyleSheet.create({
         dropdownText: {
-            color: COLORS.white,
+            ...theme.text,
             textAlign: "center",
         },
         labelStyle: {
@@ -296,7 +296,7 @@ export const Dropdown_Select = (props:{validationLabel?:string, saveKey?:boolean
             justifyContent: "center"
         },
         dropdownSelected: {
-            color: COLORS.white,
+            ...theme.text,
             textAlign: "center",
             flex: 1,
             paddingLeft: 16
@@ -311,11 +311,13 @@ export const Dropdown_Select = (props:{validationLabel?:string, saveKey?:boolean
             marginBottom: 5,
             ...props.validationStyle
         },
-          
+        dropdownIcon: {
+            paddingTop: theme.text.fontSize / 2,
+        }
     });
     
     return (
-        <View style={styles.containerStyle}>
+        <View style={styles.containerStyle} >
             {props.label && <Text style={styles.labelStyle}>{props.label}</Text>}
             <SelectList 
                 setSelected={(val: string) => props.setSelected(val)}
@@ -324,9 +326,18 @@ export const Dropdown_Select = (props:{validationLabel?:string, saveKey?:boolean
                 boxStyles={styles.selectBoxStyle} 
                 dropdownTextStyles={styles.dropdownText}
                 inputStyles={styles.dropdownSelected}
-                placeholder={props.placeholder}
+                placeholder={props.placeholder ?? props.defaultOption?.value}
                 defaultOption={props.defaultOption} 
-             />
+                search={false}
+                arrowicon={
+                    <Ionicons
+                        name={'chevron-down'}
+                        color={COLORS.accent}
+                        size={theme.text.fontSize} 
+                        style={styles.dropdownIcon}
+                    />
+                }
+            />
             {props.validationLabel && <Text style={styles.errorTextStyle}>{props.validationLabel}</Text>}
 
         </View>
@@ -339,7 +350,7 @@ export const Multi_Dropdown_Select = (props:{validationLabel?:string, setSelecte
 
     const styles = StyleSheet.create({
         dropdownText: {
-            color: COLORS.white,
+            ...theme.text,
             textAlign: "center",
             
         },
@@ -351,7 +362,7 @@ export const Multi_Dropdown_Select = (props:{validationLabel?:string, setSelecte
             ...props.labelStyle,
         },
         dropdownSelected: {
-            color: COLORS.white,
+            ...theme.text,
             textAlign: "center",
             paddingLeft: 16,
             flex: 1 
@@ -366,7 +377,9 @@ export const Multi_Dropdown_Select = (props:{validationLabel?:string, setSelecte
             marginBottom: 5,
             ...props.validationStyle
         },
-          
+        dropdownIcon: {
+            paddingTop: theme.text.fontSize / 2,
+        }
     });
     
     return (
@@ -382,6 +395,15 @@ export const Multi_Dropdown_Select = (props:{validationLabel?:string, setSelecte
                 placeholder={props.placeholder}
                 defaultOptions={props.defaultOptions}
                 checkBoxStyles={props.checkBoxStyles}
+                search={false}
+                arrowicon={
+                    <Ionicons
+                        name={'chevron-down'}
+                        color={COLORS.accent}
+                        size={theme.text.fontSize} 
+                        style={styles.dropdownIcon}
+                    />
+                }
              />
             {props.validationLabel && <Text style={styles.errorTextStyle}>{props.validationLabel}</Text>}
 

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -79,9 +79,29 @@ export const Outline_Button = (props:{text:string|JSX.Element, buttonStyle?:View
     return ( <Flat_Button {...props} buttonStyle={styles.buttonStyle}/> );    
 }
 
+//Not Header, Included in page scroll
+export const Page_Title = (props:{title:string, containerStyle?:ViewStyle, textStyle?:TextStyle}):JSX.Element => {
+    const styles = StyleSheet.create({
+        containerStyle: {
+            width: '100%',
+            padding: theme.header.fontSize / 2,
+            ...props.containerStyle
+        },
+        textStyle: {
+            ...theme.header,
+            textAlign: 'center',
+            ...props.textStyle
+        }
+    });
+
+    return ( <View style={styles.containerStyle}>
+                <Text style={styles.textStyle}>{props.title}</Text>
+            </View> );
+}
+
 
 /* Horizontal Multi Tab Selector */
-export const Tab_Selector = (props:{optionList:string[], defaultIndex:number|undefined, onSelect:(name:string, index:number) => void, onDeselect?:() => void, style?:ViewStyle, isHeader?:boolean }) => {
+export const Tab_Selector = (props:{optionList:string[], defaultIndex:number|undefined, onSelect:(name:string, index:number) => void, onDeselect?:() => void, containerStyle?:ViewStyle, textStyle?:TextStyle }) => {
 
     const [selectedIndex, setSelectedIndex] = useState<number|undefined>(props.defaultIndex);
 
@@ -91,13 +111,13 @@ export const Tab_Selector = (props:{optionList:string[], defaultIndex:number|und
             padding: 0,
             borderTopWidth: 1,
             borderBottomWidth: 1,
-            borderColor: (props.isHeader) ? COLORS.primary : COLORS.accent,
-            ...props.style,
+            borderColor: (props.textStyle?.color) ? props.textStyle.color : COLORS.accent,
+            ...props.containerStyle,
           },
           filterSelected: {
             paddingVertical: 1,
             paddingHorizontal: 10,
-            backgroundColor: (props.isHeader) ? COLORS.primary : COLORS.accent,
+            backgroundColor: (props.textStyle?.color) ? props.textStyle.color : COLORS.accent,
           },
           filterNotSelected: {
             paddingVertical: 1,
@@ -109,10 +129,10 @@ export const Tab_Selector = (props:{optionList:string[], defaultIndex:number|und
             backgroundColor: COLORS.grayDark,
             marginVertical: 5,
           },
-          isHeaderTitle: {
-            ...theme.title,
-            color: COLORS.white,
-            fontSize: 20
+          text: {
+            ...theme.text,
+            ...props.textStyle,
+            color: (props.textStyle?.color === COLORS.white) ? COLORS.accent : COLORS.white
           }
         });
 
@@ -129,8 +149,8 @@ export const Tab_Selector = (props:{optionList:string[], defaultIndex:number|und
                             props.onDeselect();
                         }
                         }} >
-                        <Text style={(index === selectedIndex) ? [(props.isHeader) ? styles.isHeaderTitle : theme.text, styles.filterSelected] 
-                            : [(props.isHeader) ? styles.isHeaderTitle : theme.text, styles.filterNotSelected] }>{makeDisplayText(item)}</Text>
+                        <Text style={(index === selectedIndex) ? [styles.text, styles.filterSelected] 
+                            : [styles.text, styles.filterNotSelected] }>{makeDisplayText(item)}</Text>
                     </TouchableOpacity>
                     {index < props.optionList.length - 1 && <View style={styles.divider} />}
                 </React.Fragment>                        


### PR DESCRIPTION
# Abstract SearchList 
https://trello.com/c/iGg30C0T/87-84-march-abstract-search-component-page

### Features & Changes
1. `SearchListKey` and `SearchListValue` identical to portal except `onPress` 
2.  Implemented `SearchList` modified design from portal
    3. Configurable for multiple list display with default multi list or filter views
    4. Header variability with title, filter, search, all optional configurable  as props
    5. Search via type and local caching
    **Note: Not every listItem implements `primaryButton` and `secondaryButton`; I think that's okay as long as we're aware.
7. Transition `ContentDisplay` to `SearchList` design
8. `ContentCard` tracking and unmounting `isMounted` due to syncing issues with `setAspectRatio`
9. `debouceHook` for identifying pause in typing before initiating the server search
10. Add styling for `Page_Title` and `Page_Selector` widgets (More app uniformity)
11. Added `dropdownIcon` for `Dropdown_Select` and `Multi_Dropdown_Select` widgets
12. Made `ProfileImage` widget optionally clickable



### Content Page appears nearily identical with framework behind the scenes
![Screenshot 2024-07-04 022822](https://github.com/PEW35MINISTRY/mobile/assets/53985473/8d1d00da-ff77-497a-a1d1-2b006a40b297)

