### PR TITLE
141 autologin android

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1129,7 +1129,7 @@ PODS:
     - React-Core
   - RNInAppBrowser (3.4.0):
     - React
-  - RNKeychain (9.0.0):
+  - RNKeychain (9.2.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1448,7 +1448,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 4f3c4dbd4f908be32ec8c93f086e8924bd4a2e07
   RNGestureHandler: 1155b1898ceddefeebf77792927360d44fe11e77
   RNInAppBrowser: c1a0dad2734458d79bcb6c8f4297ba8658a1da9f
-  RNKeychain: 8ca3a8ab36b2e67c961199132d96f3291e7696ac
+  RNKeychain: 4b4e8c588f3d4bdc82aeaabd3078b11701f130a0
   RNReanimated: ba95f6d26ca4b8a8f7f2b15f62a3513750762f6b
   RNScreens: 29418ceffb585b8f0ebd363de304288c3dce8323
   RNVectorIcons: 96e8c5c45609932bb2f8347e1c709bcca0e95654

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-native-gesture-handler": "^2.14.0",
         "react-native-image-picker": "^7.1.0",
         "react-native-inappbrowser-reborn": "3.4.0",
-        "react-native-keychain": "^9.0.0",
+        "react-native-keychain": "^9.2.2",
         "react-native-modal-datetime-picker": "^15.0.1",
         "react-native-reanimated": "^3.6.0",
         "react-native-root-toast": "^3.5.1",
@@ -7959,10 +7959,9 @@
       }
     },
     "node_modules/react-native-keychain": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-9.0.0.tgz",
-      "integrity": "sha512-pANzNE3Rcr2vVRdJpxY4RV+VhLwV6xPchndeycqpmY+dUl0kCYOkzS7WuCS4TlXR4rLdQq07TmCgNXfyRGmVyw==",
-      "license": "MIT",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-9.2.2.tgz",
+      "integrity": "sha512-sATwVC76fEl4fsdBsgzG6lwhUhKduK0yqPBKHQRrJlv/2/HFBLXc4yLk9SKnZdgVHCpBxIEX4obMyMcu3HBh9w==",
       "workspaces": [
         "KeychainExample",
         "website"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-native-gesture-handler": "^2.14.0",
     "react-native-image-picker": "^7.1.0",
     "react-native-inappbrowser-reborn": "3.4.0",
-    "react-native-keychain": "^9.0.0",
+    "react-native-keychain": "^9.2.2",
     "react-native-modal-datetime-picker": "^15.0.1",
     "react-native-reanimated": "^3.6.0",
     "react-native-root-toast": "^3.5.1",

--- a/src/redux-store.tsx
+++ b/src/redux-store.tsx
@@ -215,8 +215,8 @@ export const saveSettingsMiddleware:Middleware = store => next => action => {
     keychain.setGenericPassword('settings', JSON.stringify(settingsState), {service: storeRef.account.userID.toString()});
 
   } else if(action.type === resetSettings.type) {
-    const userID = store.getState().account.userID.toString();
-    keychain.resetGenericPassword({service: userID});
+    const storeRef = store.getState();
+    keychain.setGenericPassword('settings', JSON.stringify(initialSettingsState), {service: storeRef.account.userID.toString()});
   }
   return result;
 };


### PR DESCRIPTION
After some thorough testing, I discovered that this issue only happens in my local environment when the react native debugger is used. When the app is installed standalone on a device, the keychain works fine.

Bumped the version of the package anyways, and included a small change to save the initial settings state to the keychain when a reset is requested.