### PR TITLE
134-stale-partnership

### DIFF
--- a/src/1-Profile/profile-widgets.tsx
+++ b/src/1-Profile/profile-widgets.tsx
@@ -46,7 +46,7 @@ export const RequestorProfileImage = (props:{style?:ImageStyle, imageUri?:string
             if (props.userID == userID) setRequestorImage({uri: userProfileImage})
             else fetchProfileImage();
         }
-    },[userProfileImage])
+    },[userProfileImage, props.imageUri, props.userID])
     return <Image source={requestorImage} style={styles.profileImage} resizeMode="contain"></Image> 
 }
 


### PR DESCRIPTION
This was an interesting one. Due to how rendering works in React Native, the ``RequestorProfileImage`` widget was getting replaced by the previously rendered image from the deleted partner.

By adding dependencies to ``useEffect``, I was able to fix this by allowing the component to re-render itself to display the correct profile image. Testing showed that all the existing parameters and functionality was working as expected.