### PR TITLE
add platform OS to device create route

### DIFF
--- a/src/TypesAndInterfaces/config-sync/api-type-sync/notification-types.ts
+++ b/src/TypesAndInterfaces/config-sync/api-type-sync/notification-types.ts
@@ -16,7 +16,7 @@ export type NotificationDeviceVerify = {
 export type NotificationDeviceSignup = {
     deviceToken: string,
     deviceName?: string,
-    deviceOS?: string
+    deviceOS: string
 }
 
 export interface NotificationDeviceListItem {

--- a/src/TypesAndInterfaces/config-sync/input-config-sync/notification-field-config.ts
+++ b/src/TypesAndInterfaces/config-sync/input-config-sync/notification-field-config.ts
@@ -10,8 +10,8 @@ import InputField, { InputType } from './inputField';
 //New Device Entry; endpointARN is assigned by server
 export const NOTIFICATION_DEVICE_FIELDS:InputField[] = [
     new InputField({title: 'Device Name', field: 'deviceName', type:InputType.TEXT, validationRegex: new RegExp(/^[a-zA-Z0-9' _.-]{1,100}$/), validationMessage: 'Required, 5-100 chars, letters, numbers, dashes, underscores.' }),
-    new InputField({title: 'Token', field: 'deviceToken', type:InputType.TEXT, validationRegex: new RegExp(/^[a-zA-Z0-9.:_-]{1,255}$/), validationMessage: 'Required, 5-100 chars, letters, numbers, dashes, underscores.' })
-];
+    new InputField({title: 'Token', field: 'deviceToken', type:InputType.TEXT, validationRegex: new RegExp(/^[a-zA-Z0-9.:_-]{1,255}$/), validationMessage: 'Required, 5-100 chars, letters, numbers, dashes, underscores.' }),
+    new InputField({title: 'DeviceOS', field: 'deviceOS', type:InputType.TEXT, validationRegex: new RegExp(/^ANDROID|IOS$/), validationMessage: 'Required, must be one of ANDROID or iOS' })];
 
 //Only fields saved to out database are editable
 export const EDIT_NOTIFICATION_DEVICE_FIELDS_ADMIN:InputField[] = [

--- a/src/redux-store.tsx
+++ b/src/redux-store.tsx
@@ -10,6 +10,7 @@ import axios, { Axios, AxiosError, AxiosResponse } from 'axios';
 import { generateDefaultDeviceName } from './utilities/notifications';
 import { ServerErrorResponse } from './TypesAndInterfaces/config-sync/api-type-sync/utility-types';
 import { DeviceVerificationResponseType } from './TypesAndInterfaces/config-sync/api-type-sync/notification-types';
+import { Platform } from 'react-native';
 
 /******************************
    Account | Credentials Redux Reducer
@@ -219,7 +220,7 @@ export const registerNotificationDevice = async(dispatch: (arg0: { payload: numb
   const deviceToken = reduxState.deviceToken;
 
   if (deviceID === -1) {
-    const response:AxiosResponse<string> = await axios.post(`${DOMAIN}/api/user/${userID}/notification/device`, {deviceToken: deviceToken, deviceName: generateDefaultDeviceName()}, { headers: { jwt }});
+    const response:AxiosResponse<string> = await axios.post(`${DOMAIN}/api/user/${userID}/notification/device`, {deviceToken: deviceToken, deviceName: generateDefaultDeviceName(), deviceOS: Platform.OS.toUpperCase()}, { headers: { jwt }});
     const responseDeviceID = parseInt(response.data);
     if (responseDeviceID !== deviceID) dispatch(setDeviceID(responseDeviceID));
   } else {


### PR DESCRIPTION
Got notifications working on iOS again. See the server PR for more details.

On the mobile side, we need to let the server know what OS the client device is so we can create a endpoint in SNS for the appropriate platform. 