### PR TITLE
Image inconsistencies

### DIFF
--- a/src/0-Pages/Login.tsx
+++ b/src/0-Pages/Login.tsx
@@ -42,7 +42,6 @@ const Login = ({navigation, route}:LoginProps):JSX.Element => {
     }
 
     const onEmailLogin = (formValues:Record<string, string | string[]>) => {
-      console.log(DOMAIN);
         axios.post(`${DOMAIN}/login`, formValues).then(async (response:AxiosResponse<LoginResponseBody>) => {   
 
           dispatch(setAccount({

--- a/src/0-Pages/Login.tsx
+++ b/src/0-Pages/Login.tsx
@@ -42,6 +42,7 @@ const Login = ({navigation, route}:LoginProps):JSX.Element => {
     }
 
     const onEmailLogin = (formValues:Record<string, string | string[]>) => {
+      console.log(DOMAIN);
         axios.post(`${DOMAIN}/login`, formValues).then(async (response:AxiosResponse<LoginResponseBody>) => {   
 
           dispatch(setAccount({

--- a/src/1-Profile/profile-widgets.tsx
+++ b/src/1-Profile/profile-widgets.tsx
@@ -41,12 +41,13 @@ export const RequestorProfileImage = (props:{style?:ImageStyle, imageUri?:string
     }
 
     useEffect(() => {
-        if (props.imageUri !== undefined && props.imageUri !== "" && props.imageUri !== null) setRequestorImage({uri: props.imageUri})
-        else if (props.userID !== undefined) {
-            if (props.userID == userID) setRequestorImage({uri: userProfileImage})
-            else fetchProfileImage();
+        if (props.userID !== undefined && props.userID === userID && userProfileImage !== undefined) {
+            setRequestorImage({uri: userProfileImage})
         }
-    },[userProfileImage, props.imageUri, props.userID])
+        else if (props.imageUri !== undefined && props.imageUri !== "" && props.imageUri !== null) setRequestorImage({uri: props.imageUri})
+        else if (props.userID !== undefined) fetchProfileImage();
+    },[userProfileImage, props.imageUri, props.userID]);
+
     return <Image source={requestorImage} style={styles.profileImage} resizeMode="contain"></Image> 
 }
 

--- a/src/Widgets/SearchList/SearchList.tsx
+++ b/src/Widgets/SearchList/SearchList.tsx
@@ -275,7 +275,7 @@ const SearchList = ({...props}:{key:any, name:string, pageTitle?:string, display
                 >
 
                     {(searchTerm !== undefined) ?
-                        <Text allowFontScaling={false}Input
+                        <TextInput allowFontScaling={false}
                             style={styles.searchInput}
                             placeholder={'Search...'}
                             placeholderTextColor={COLORS.accent}


### PR DESCRIPTION
Previously, when a user updated their profile image, the change did not propagate throughout the rest of the app. This is because the file name stays static on the server side (as long as the file extension is the same). 

Small refactor to reorganize the priority logic for which how to display a user's image.