### PR TITLE
chore: update AGP to 8.8.2, fix gradle config, bug fixes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,6 +2,14 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 apply from: file("../../node_modules/react-native-vector-icons/fonts.gradle")
+
+configurations.all {
+    resolutionStrategy {
+        force "androidx.annotation:annotation:1.9.1"
+        force "androidx.annotation:annotation-jvm:1.9.1"
+    }
+}
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.
@@ -80,8 +88,8 @@ android {
         applicationId "com.pew35.encouragingprayer"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 9
-        versionName "9.0"
+        versionCode 14
+        versionName "14.0"
     }
     signingConfigs {
         debug {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 35
         androidXBrowser = "1.4.0"
-        ndkVersion = "25.1.8937393"
+        ndkVersion = "26.1.10909125"
         kotlinVersion = "1.8.0"
     }
     repositories {
@@ -13,7 +13,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath('com.android.tools.build:gradle:8.8.2')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
         classpath 'com.google.gms:google-services:4.4.2'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/10-Dashboard/DashboardDisplay.tsx
+++ b/src/10-Dashboard/DashboardDisplay.tsx
@@ -70,7 +70,7 @@ const DashboardDisplay = ({navigation}:StackNavigationProps):JSX.Element => {
                         ],
                         [
                             new SearchListKey({displayTitle:'Partner Requests'}),
-                            [...partnerPendingUserList].map((partner) => new SearchListValue({displayType: ListItemTypesEnum.PARTNER, displayItem: partner,
+                            [...partnerPendingUserList].map((partner) => new SearchListValue({displayType: ListItemTypesEnum.PENDING_PARTNER, displayItem: partner,
                                 primaryButtonText:'View Contract', onPrimaryButtonCallback:(id:number, item) => setNewPartner(item as PartnerListItem)}))
                         ],
                         [


### PR DESCRIPTION
After merging the App Overview page, I found that our app was failing to build on android even though I used the same dependency versions and configs. I dug around a bit with Kiro and found a few things:

- Android SDK 35 doesn't officially support AGP 8.1.1 (which we were using). Updated to 8.8.2 which is the earliest major version that does
- react-native-inappbrowser-reborn had a unrestricted kotlin dependency chain which depended on a kotlin version higher than what 1.8 could handle
- The appVersion of our app is not accurate in mainline. I've been bumping it manually when I build the app for release locally
- fixed logic bug in dashboard from back in February that shows wrong button when partnership is pending