### PR TITLE
[291] user, content, comment, and prayer request reporting

### DIFF
--- a/src/10-Dashboard/DashboardDisplay.tsx
+++ b/src/10-Dashboard/DashboardDisplay.tsx
@@ -1,7 +1,7 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import React, { useEffect, useState } from 'react';
-import { View, StyleSheet, SafeAreaView } from 'react-native';
-import { addMemberCircle, addPartner, addPartnerPendingPartner, removeInviteCircle, removePartnerPendingUser, RootState, setTabFocus } from '../redux-store';
+import { View, StyleSheet, SafeAreaView, Modal } from 'react-native';
+import { addMemberCircle, addPartner, addPartnerPendingPartner, removeInviteCircle, removePartnerPendingUser, removeRecommendedContent, RootState, setTabFocus } from '../redux-store';
 import theme, { COLORS, FONT_SIZES } from '../theme';
 import { DOMAIN } from '@env';
 import { useAppDispatch, useAppSelector } from '../TypesAndInterfaces/hooks';
@@ -16,7 +16,7 @@ import { ListItemTypesEnum } from '../TypesAndInterfaces/config-sync/input-confi
 import { PartnerListItem } from '../TypesAndInterfaces/config-sync/api-type-sync/profile-types';
 import { CircleAnnouncementListItem, CircleListItem, CircleResponse } from '../TypesAndInterfaces/config-sync/api-type-sync/circle-types';
 import { PrayerRequestListItem } from '../TypesAndInterfaces/config-sync/api-type-sync/prayer-request-types';
-import { Flat_Button, ProfileImage } from '../widgets';
+import { Confirmation, Flat_Button, ProfileImage } from '../widgets';
 import { BOTTOM_TAB_NAVIGATOR_ROUTE_NAMES, ROUTE_NAMES } from '../TypesAndInterfaces/routes';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import { PartnershipContractModal } from '../4-Partners/partnership-widgets';
@@ -36,6 +36,23 @@ const DashboardDisplay = ({navigation}:StackNavigationProps):JSX.Element => {
     const expiringPrayerRequestList:PrayerRequestListItem[] = useAppSelector((state:RootState) => state.account.userProfile.expiringPrayerRequestList) || [];
     const recommendedContentList:ContentListItem[] = useAppSelector((state:RootState) => state.account.userProfile.recommendedContentList) || [];
     const [newPartner, setNewPartner] = useState<PartnerListItem|undefined>(undefined);
+    const [reportModalVisible, setReportModalVisible] = useState(false);
+    const [reportedContentID, setReportedContentID] = useState<number>(0);
+
+    const RequestAccountHeader = {
+        headers: {
+            "jwt": jwt,
+        }
+    }
+
+    const reportContent = async () => {
+        await axios.post(`${DOMAIN}/api/content-archive/${reportedContentID}/report`, {}, RequestAccountHeader).then((response) => {
+            setReportModalVisible(false);
+            dispatch(removeRecommendedContent(reportedContentID));
+            setReportedContentID(-1);
+            ToastQueueManager.show({message: 'Report received'})
+        }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
+    }
 
     return (
         <SafeAreaView style={styles.pageContainer} >
@@ -95,7 +112,7 @@ const DashboardDisplay = ({navigation}:StackNavigationProps):JSX.Element => {
                         ],
                         [
                             new SearchListKey({displayTitle:'Recommended'}),
-                            [...recommendedContentList].map((content) => new SearchListValue({displayType: ListItemTypesEnum.CONTENT_ARCHIVE, displayItem: content }))
+                            [...recommendedContentList].map((content) => new SearchListValue({displayType: ListItemTypesEnum.CONTENT_ARCHIVE, displayItem: content, onAlternativeButtonCallback: (id, item) => { setReportedContentID(id); setReportModalVisible(true); } }))
                         ],
                     ])}
                 footerItems={[
@@ -126,6 +143,21 @@ const DashboardDisplay = ({navigation}:StackNavigationProps):JSX.Element => {
                     onClose={() => setNewPartner(undefined)}
                 />
         }
+
+            <Modal 
+                visible={reportModalVisible}
+                onRequestClose={() => setReportModalVisible(false)}
+                animationType='slide'
+                transparent={true}
+            >
+                <Confirmation 
+                    callback={() => reportContent()}
+                    onCancel={() => setReportModalVisible(false)}
+                    promptText={'report this content? This action will remove this content from your feed and send a report to our team for review.'}
+                    buttonText='Report'
+                    addPunctuation={false}
+                />
+            </Modal>
         </SafeAreaView>
     );
 };

--- a/src/3-Prayer-Request/PrayerRequestDisplay.tsx
+++ b/src/3-Prayer-Request/PrayerRequestDisplay.tsx
@@ -1,16 +1,16 @@
 import { DOMAIN, PRAYER_REQUEST_TIME_COUNT_MAX } from '@env';
 import axios, { AxiosError } from 'axios';
 import React, { useEffect, useRef, useState } from 'react';
-import { GestureResponderEvent, Image, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View, TextInput, SafeAreaView, KeyboardAvoidingView } from 'react-native';
+import { GestureResponderEvent, Image, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View, TextInput, SafeAreaView, KeyboardAvoidingView, DeviceEventEmitter } from 'react-native';
 import { PrayerRequestCommentListItem, PrayerRequestListItem, PrayerRequestResponseBody } from '../TypesAndInterfaces/config-sync/api-type-sync/prayer-request-types';
 import { useAppDispatch, useAppSelector } from '../TypesAndInterfaces/hooks';
-import { addAnsweredPrayerRequest, addOwnedPrayerRequest, removeAnsweredPrayerRequest, removeExpiringPrayerRequest, removeOwnedPrayerRequest, RootState, setOwnedPrayerRequests, setPrayerRequestPrayedState, setPrayerRequestTimeState, updatePrayerRequestPrayedState } from '../redux-store';
+import { addAnsweredPrayerRequest, addOwnedPrayerRequest, removeAnsweredPrayerRequest, removeExpiringPrayerRequest, removeNewPrayerRequest, removeOwnedPrayerRequest, RootState, setOwnedPrayerRequests, setPrayerRequestPrayedState, setPrayerRequestTimeState, updatePrayerRequestPrayedState } from '../redux-store';
 import theme, { COLORS, FONT_SIZES } from '../theme';
 import { PrayerRequestTagEnum } from '../TypesAndInterfaces/config-sync/input-config-sync/prayer-request-field-config';
 import PrayerRequestEditForm from './PrayerRequestEditForm';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RequestorProfileImage } from '../1-Profile/profile-widgets';
-import { BackButton, EditButton, Filler } from '../widgets';
+import { BackButton, Confirmation, EditButton, Filler, ReportButton } from '../widgets';
 import { AppStackParamList, ROUTE_NAMES } from '../TypesAndInterfaces/routes';
 import { PrayerRequestComment } from './prayer-request-widgets';
 import { RequestorCircleImage } from '../2-Circles/circle-widgets';
@@ -20,7 +20,7 @@ import { CircleListItem } from '../TypesAndInterfaces/config-sync/api-type-sync/
 import { ServerErrorResponse } from '../TypesAndInterfaces/config-sync/api-type-sync/utility-types';
 import ToastQueueManager from '../utilities/ToastQueueManager';
 import Ionicons from 'react-native-vector-icons/Ionicons';
-import { set } from 'react-hook-form';
+import Toast from 'react-native-toast-message';
 
 export interface PrayerRequestDisplayParamList{
     PrayerRequestProps: PrayerRequestListItem,
@@ -63,9 +63,12 @@ const PrayerRequestDisplay = ({navigation, route}:PrayerRequestDisplayProps):JSX
     const [circleRecipientData, setCircleRecipientData] = useState<CircleListItem[]>([]);
     const [tags, setTags] = useState<PrayerRequestTagEnum[]>([]);
     const [prayerRequestEditModalVisible, setPrayerRequestEditModalVisible] = useState(false);
+    const [reportPrayerRequestModalVisible, setReportPrayerRequestModalVisible] = useState(false);
+    const [reportCommentModalVisible, setReportCommentModalVisible] = useState(false);
     const [commentCreateModalVisible, setCommentCreateModalVisible] = useState(false);
     const [recipientPrayerCount, setRecipientPrayerCount] = useState<number>(0);
     const [userHasOpenedEditModal, setUserHasOpenedEditModal] = useState(false); // prevent recursive loading of the edit modal
+    const [reportedCommentID, setReportedCommentID] = useState<number>(0);
 
     const dispatch = useAppDispatch();
 
@@ -75,10 +78,15 @@ const PrayerRequestDisplay = ({navigation, route}:PrayerRequestDisplayProps):JSX
         }   
     }
 
+    const removeCommentLocal = (commentID:number) => {
+        setCommentsData((commentsData || []).filter((commentItem:PrayerRequestCommentListItem) => commentItem.commentID !== commentID ));
+    }
+    
     const renderComments = ():JSX.Element[] =>
         (commentsData || []).map((comment:PrayerRequestCommentListItem, index:number) => 
-            <PrayerRequestComment commentProp={comment} key={index} callback={(commentID:number) => {setCommentsData((commentsData || []).filter((commentItem:PrayerRequestCommentListItem) => commentItem.commentID !== commentID )); ToastQueueManager.show({message: "Comment deleted"});
-}} />
+            <PrayerRequestComment commentProp={comment} key={index} onDelete={(commentID:number) => { removeCommentLocal(commentID); ToastQueueManager.show({message: "Comment deleted"}); }} 
+                onReport={() => { setReportedCommentID(comment.commentID); setReportCommentModalVisible(true);  }} 
+            />
         );
 
     const renderUserRecipients = ():JSX.Element[] => 
@@ -102,6 +110,15 @@ const PrayerRequestDisplay = ({navigation, route}:PrayerRequestDisplayProps):JSX
         return textProps;
     }
 
+    const reportComment = async () => {
+        await axios.post(`${DOMAIN}/api/prayer-request/${currPrayerRequestState?.prayerRequestID}/comment/${reportedCommentID}/report`, {}, RequestAccountHeader).then((response) => {
+            removeCommentLocal(reportedCommentID);
+            setReportedCommentID(0);
+            setReportCommentModalVisible(false);
+            ToastQueueManager.show({message: 'Report received'})
+        }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
+    }
+
     const onPrayPress = async () => {
         if (currPrayerRequestState !== undefined ) {
             await axios.post(`${DOMAIN}/api/prayer-request/` + currPrayerRequestState?.prayerRequestID + '/like', {}, RequestAccountHeader).then((response) => {
@@ -109,6 +126,21 @@ const PrayerRequestDisplay = ({navigation, route}:PrayerRequestDisplayProps):JSX
                 setRecipientPrayerCount((count) => count + 1);
             }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
         }
+    }
+
+    const reportPrayerRequest = async () => {
+        await axios.post(`${DOMAIN}/api/prayer-request/${currPrayerRequestState?.prayerRequestID}/report`, {}, RequestAccountHeader).then((response) => {
+
+            // index represents which tab in the BottomTabNavigator is focused
+            const parentNavigationIndex = navigation.getParent()?.getState()?.index || -1;
+
+            setReportPrayerRequestModalVisible(false);
+            dispatch(removeNewPrayerRequest(currPrayerRequestState?.prayerRequestID || -1));
+
+            //parentNavigationIndex === 2 && 
+            DeviceEventEmitter.emit('prayerRequestReported', currPrayerRequestState?.prayerRequestID); // only emit event if user viewed prayer request from Prayer Request List page
+            navigation.goBack();
+        }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
     }
 
     const setPrayerRequestState = (prayerRequestData:PrayerRequestResponseBody) => {
@@ -288,6 +320,34 @@ const PrayerRequestDisplay = ({navigation, route}:PrayerRequestDisplayProps):JSX
                             </View>
 
                         </Modal>
+                        <Modal 
+                            visible={reportPrayerRequestModalVisible}
+                            onRequestClose={() => setReportPrayerRequestModalVisible(false)}
+                            animationType='slide'
+                            transparent={true}
+                        >
+                            <Confirmation 
+                                callback={() => reportPrayerRequest()}
+                                onCancel={() => setReportPrayerRequestModalVisible(false)}
+                                promptText={'report this prayer request? This action will remove this prayer request from your feed and send a report to our team for review.'}
+                                buttonText='Report'
+                                addPunctuation={false}
+                            />
+                        </Modal>
+                        <Modal 
+                            visible={reportCommentModalVisible}
+                            onRequestClose={() => setReportCommentModalVisible(false)}
+                            animationType='slide'
+                            transparent={true}
+                        >
+                            <Confirmation 
+                                callback={() => reportComment()}
+                                onCancel={() => setReportCommentModalVisible(false)}
+                                promptText={'report this comment? This action will remove this comment from your feed and send a report to our team for review.'}
+                                buttonText='Report'
+                                addPunctuation={false}
+                            />
+                        </Modal>
                         {
                             (commentsData !== undefined && commentsData.length !== 0) && <Text allowFontScaling={false} style={styles.commentsTitle}>Comments</Text>
                         }
@@ -313,8 +373,9 @@ const PrayerRequestDisplay = ({navigation, route}:PrayerRequestDisplayProps):JSX
 
                        
                     </View>
-                    {appPrayerRequestListItem.requestorProfile.userID === userID && <EditButton callback={() => setPrayerRequestEditModalVisible(true)} /> }
+                    {appPrayerRequestListItem.requestorProfile.userID === userID ? <EditButton callback={() => setPrayerRequestEditModalVisible(true)} /> : <ReportButton callback={() => setReportPrayerRequestModalVisible(true)} />}
                     <BackButton navigation={navigation} />
+                    
                 </View>    
             )
         }

--- a/src/3-Prayer-Request/PrayerRequestList.tsx
+++ b/src/3-Prayer-Request/PrayerRequestList.tsx
@@ -1,21 +1,20 @@
 import { DOMAIN } from '@env';
 import axios, { all, AxiosError } from 'axios';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Image, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View, TextInput, SafeAreaView, Platform } from 'react-native';
+import { Image, Modal, ScrollView, StyleSheet, Text, TouchableOpacity, View, TextInput, SafeAreaView, Platform, DeviceEventEmitter } from 'react-native';
 import { useAppDispatch, useAppSelector } from '../TypesAndInterfaces/hooks';
 import { RootState, setAnsweredPrayerRequestList, setOwnedPrayerRequests } from '../redux-store';
 import { PrayerRequestListItem } from '../TypesAndInterfaces/config-sync/api-type-sync/prayer-request-types';
 import theme, { COLORS, FONT_SIZES } from '../theme';
 import PrayerRequestCreate from './PrayerRequestCreateForm';
 import { StackNavigationProps } from '../TypesAndInterfaces/custom-types';
-import { PrayerRequestTouchable } from './prayer-request-widgets';
 import { ROUTE_NAMES } from '../TypesAndInterfaces/routes';
 import { ServerErrorResponse } from '../TypesAndInterfaces/config-sync/api-type-sync/utility-types';
 import ToastQueueManager from '../utilities/ToastQueueManager';
 import { Filler, FolderButton } from '../widgets';
 import SearchList from '../Widgets/SearchList/SearchList';
 import { SearchFilterIdentifiable, SearchListKey, SearchListValue } from '../Widgets/SearchList/searchList-types';
-import { ListItemTypesEnum, SearchType } from '../TypesAndInterfaces/config-sync/input-config-sync/search-config';
+import { DisplayItemType, ListItemTypesEnum, SearchType } from '../TypesAndInterfaces/config-sync/input-config-sync/search-config';
 
 const MOBILE_SUPPORTED_PRAYER_REQUEST_FILTERS = ['Friends', 'Mine'];
 
@@ -48,10 +47,10 @@ const PrayerRequestList = ({navigation, route}:StackNavigationProps):JSX.Element
     
 
     const assembleAggregatedPrayerRequestList = async () => {
-        const recipientPrayerRequests = await GET_UserIsRecipientPrayerRequests();
+        const receivingPrayerRequests = await GET_UserIsRecipientPrayerRequests();
 
         // sort both lists by edited date
-        const allPrayerRequests = [...(ownedPrayerRequestList || []), ...recipientPrayerRequests].sort((a, b) => new Date(a.modifiedDT) > new Date(b.modifiedDT) ? -1 : 1 );
+        const allPrayerRequests = [...(ownedPrayerRequestList || []), ...receivingPrayerRequests].sort((a, b) => new Date(a.modifiedDT) > new Date(b.modifiedDT) ? -1 : 1 );
 
         setAggregatePrayerRequests(allPrayerRequests);
     };
@@ -61,10 +60,28 @@ const PrayerRequestList = ({navigation, route}:StackNavigationProps):JSX.Element
         setAggregatePrayerRequests(allPrayerRequests);
     }
 
+    const onReportPrayerRequest = (id: number) => {
+        ToastQueueManager.show({message: 'Report received'})
+
+        setRecipientPrayerRequests(recipientPrayerRequests.filter(prayerRequest => prayerRequest.prayerRequestID !== id));
+    }
+
     useEffect(() => {
         if (recipientPrayerRequests.length === 0) assembleAggregatedPrayerRequestList();
         else updateAggregatedPrayerRequestList();
-    }, [ownedPrayerRequestList]);
+    }, [ownedPrayerRequestList, recipientPrayerRequests]);
+
+    useEffect(() => {
+
+        // create event emitter to listen for prayer request reporting
+        const subscription = DeviceEventEmitter.addListener('prayerRequestReported', (id: number) => {
+            onReportPrayerRequest(id);
+        });
+          
+        return () => {
+            subscription.remove();
+        };
+    }, []);
 
  return (
         <SafeAreaView style={styles.backgroundColor}>

--- a/src/3-Prayer-Request/prayer-request-widgets.tsx
+++ b/src/3-Prayer-Request/prayer-request-widgets.tsx
@@ -11,6 +11,7 @@ import { RequestorProfileImage } from "../1-Profile/profile-widgets";
 import Ionicons from "react-native-vector-icons/Ionicons";
 import { ServerErrorResponse } from "../TypesAndInterfaces/config-sync/api-type-sync/utility-types";
 import ToastQueueManager from "../utilities/ToastQueueManager";
+import { ReportButton } from "../widgets";
 
 export const PrayerRequestTouchable = (props:{prayerRequestProp:PrayerRequestListItem, onPress?:((id:number, item:PrayerRequestListItem) => void), callback?:(() => void)}):JSX.Element => {
     const PRAYER_ICON_ACCENT = require('../../assets/prayer-icon-blue.png');
@@ -174,7 +175,7 @@ export const PrayerRequestTouchable = (props:{prayerRequestProp:PrayerRequestLis
 }
 
 
-export const PrayerRequestComment = (props:{commentProp:PrayerRequestCommentListItem, callback:((commentID:number) => void), visible?:boolean}):JSX.Element => {
+export const PrayerRequestComment = (props:{commentProp:PrayerRequestCommentListItem, onDelete:((commentID:number) => void), onReport:((commentID:number) => void), visible?:boolean}):JSX.Element => {
     const jwt = useAppSelector((state: RootState) => state.account.jwt);
     const userID = useAppSelector((state: RootState) => state.account.userProfile.userID);
     const [isLiked, setIsLiked] = useState(props.commentProp.isLikedByRecipient);
@@ -200,13 +201,12 @@ export const PrayerRequestComment = (props:{commentProp:PrayerRequestCommentList
 
     const onDeletePress = async () => {
         await axios.delete(`${DOMAIN}/api/prayer-request/` + props.commentProp.prayerRequestID + '/comment/' + props.commentProp.commentID, RequestAccountHeader).then((response) => {
-            props.callback(props.commentProp.commentID);
+            props.onDelete(props.commentProp.commentID);
         }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
     }
 
     const styles = StyleSheet.create({
         container: {
-            justifyContent: "flex-start",
             left: 15,
             marginVertical: 6,
             color: props.visible ? 'purple' : undefined
@@ -259,12 +259,17 @@ export const PrayerRequestComment = (props:{commentProp:PrayerRequestCommentList
             alignItems: "center",
             marginLeft: -50
         },
+        profileImageView: {
+            flexDirection: "column",
+        }
     });
 
     return (
         <View style={styles.container}>
             <View style={styles.prayerRequestDataTopView}>
-                <RequestorProfileImage style={{height: 30, width: 30}} imageUri={props.commentProp.commenterProfile.image}/>
+                <View style={styles.profileImageView} >
+                    <RequestorProfileImage style={{height: 30, width: 30}} imageUri={props.commentProp.commenterProfile.image}/>
+                </View>
                 <View style={styles.middleData}>
                     <Text allowFontScaling={false} style={styles.nameText}>{props.commentProp.commenterProfile.displayName}</Text>
                     <Text allowFontScaling={false} style={styles.bodyText}>{props.commentProp.message}</Text>
@@ -282,7 +287,7 @@ export const PrayerRequestComment = (props:{commentProp:PrayerRequestCommentList
                             </View>
                         </TouchableOpacity>
                     </View>
-                    { props.commentProp.commenterProfile.userID == userID && 
+                    { props.commentProp.commenterProfile.userID == userID ?
                         <View style={styles.commentDataView}>
                             <TouchableOpacity onPress={onDeletePress}>
                                 <View style={styles.socialDataView}>
@@ -292,6 +297,10 @@ export const PrayerRequestComment = (props:{commentProp:PrayerRequestCommentList
                                     />
                                 </View>
                             </TouchableOpacity>
+                        </View>
+                        : 
+                        <View style={styles.commentDataView}>
+                           {<ReportButton callback={() => props.onReport(props.commentProp.commentID)} buttonView={{ position: 'relative', top: 0, right: 0}} buttonStyle={{ height: 22, width: 22}} iconSize={20}/> } 
                         </View>
                     }
                 </View>

--- a/src/4-Partners/Partnerships.tsx
+++ b/src/4-Partners/Partnerships.tsx
@@ -149,7 +149,10 @@ const Partnerships = (props:{callback?:((state:CALLBACK_STATE) => void), continu
                 displayMap={new Map([
                         [
                             new SearchListKey({displayTitle:'Partners', searchType: SearchType.NONE }),
-                            (userProfilePartners || []).map((partnerItem) => new SearchListValue({displayType: ListItemTypesEnum.PARTNER, displayItem: partnerItem, onPrimaryButtonCallback: leavePartnership, onAlternativeButtonCallback: reportPartnership, primaryButtonText: 'Leave Partnership', alternativeButtonText: 'Report Partnership'}))
+                            (userProfilePartners || []).map((partnerItem) => new SearchListValue({displayType: ListItemTypesEnum.PARTNER, displayItem: partnerItem, 
+                                onPrimaryButtonCallback: leavePartnership, primaryButtonText: 'Leave Partnership',
+                                onAlternativeButtonCallback: reportPartnership, alternativeButtonText: 'Report Partnership'
+                            }))
                         ],
                         [
                             new SearchListKey({displayTitle:'Pending Acceptance', searchType: SearchType.NONE }),

--- a/src/4-Partners/Partnerships.tsx
+++ b/src/4-Partners/Partnerships.tsx
@@ -17,6 +17,7 @@ import SearchList from "../Widgets/SearchList/SearchList";
 import { SearchListKey, SearchListValue } from "../Widgets/SearchList/searchList-types";
 import { DisplayItemType, ListItemTypesEnum, SearchType } from "../TypesAndInterfaces/config-sync/input-config-sync/search-config";
 import { CALLBACK_STATE } from "../TypesAndInterfaces/custom-types";
+import { set } from "react-hook-form";
 
 
 const Partnerships = (props:{callback?:((state:CALLBACK_STATE) => void), continueNavigation?:boolean}):JSX.Element => {
@@ -46,6 +47,13 @@ const Partnerships = (props:{callback?:((state:CALLBACK_STATE) => void), continu
         }
     }
 
+    const assignNewPartnerFollowingReport = async (userID:number) => {
+        axios.post(`${DOMAIN}/api/user/` + userID + '/new-partner', {}, RequestAccountHeader).then((response:AxiosResponse<PartnerListItem>) => {
+            setNewPartner(response.data);
+            setPrayerContractModalVisible(true);
+        }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
+    }
+
     const acceptPartnershipRequest = (partner:PartnerListItem) => {
         axios.post(`${DOMAIN}/api/partner-pending/`+ partner.userID + '/accept', {}, RequestAccountHeader).then((response:AxiosResponse) => {
 
@@ -71,6 +79,17 @@ const Partnerships = (props:{callback?:((state:CALLBACK_STATE) => void), continu
     const declinePartnershipRequest = (partner:PartnerListItem) => {
         axios.delete(`${DOMAIN}/api/partner-pending/`+ partner.userID + '/decline', RequestAccountHeader).then((response:AxiosResponse) => {
             (partner.status == PartnerStatusEnum.PENDING_CONTRACT_PARTNER) ? dispatch(removePartnerPendingPartner(partner.userID)) : dispatch(removePartnerPendingUser(partner.userID));
+        }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
+    }
+
+    const reportPartnership = async (id: number, partner:DisplayItemType) => {
+        const requestBody = { clientID: id };
+
+        axios.post(`${DOMAIN}/api/user/${id}/report`, requestBody, RequestAccountHeader).then(async (response:AxiosResponse) => {
+            dispatch(removePartner(id));
+            ToastQueueManager.show({message: "User report received"});
+            setNewPartner({...newPartner, userID: -1});
+            setPrayerContractModalVisible(true);
         }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
     }
 
@@ -130,7 +149,7 @@ const Partnerships = (props:{callback?:((state:CALLBACK_STATE) => void), continu
                 displayMap={new Map([
                         [
                             new SearchListKey({displayTitle:'Partners', searchType: SearchType.NONE }),
-                            (userProfilePartners || []).map((partnerItem) => new SearchListValue({displayType: ListItemTypesEnum.PARTNER, displayItem: partnerItem, onPrimaryButtonCallback: leavePartnership }))
+                            (userProfilePartners || []).map((partnerItem) => new SearchListValue({displayType: ListItemTypesEnum.PARTNER, displayItem: partnerItem, onPrimaryButtonCallback: leavePartnership, onAlternativeButtonCallback: reportPartnership, primaryButtonText: 'Leave Partnership', alternativeButtonText: 'Report Partnership'}))
                         ],
                         [
                             new SearchListKey({displayTitle:'Pending Acceptance', searchType: SearchType.NONE }),
@@ -170,8 +189,7 @@ const Partnerships = (props:{callback?:((state:CALLBACK_STATE) => void), continu
             <PartnershipContractModal
                 visible={prayerContractModalVisible}
                 partner={newPartner}
-                assignPartnership={() => {acceptPartnershipRequest(newPartner); setPrayerContractModalVisible(false)}}
-                //declinePartnershipRequest={() => {declinePartnershipRequest(newPartner); setPrayerContractModalVisible(false)}}
+                assignPartnership={() => {newPartner.userID > 0 && acceptPartnershipRequest(newPartner); setPrayerContractModalVisible(false)}}
                 onClose={() => setPrayerContractModalVisible(false)}
             />
 

--- a/src/4-Partners/partnership-widgets.tsx
+++ b/src/4-Partners/partnership-widgets.tsx
@@ -4,12 +4,13 @@ import { StyleSheet, View, Text, TouchableOpacity, Modal, Image } from 'react-na
 import { PartnerListItem } from "../TypesAndInterfaces/config-sync/api-type-sync/profile-types"
 import { RequestorProfileImage } from "../1-Profile/profile-widgets";
 import { PARTNERSHIP_CONTRACT_BLURB } from "../TypesAndInterfaces/config-sync/input-config-sync/profile-field-config";
-import { Confirmation, Raised_Button } from "../widgets";
+import { Confirmation, Raised_Button, ReportButton } from "../widgets";
 import Toast from "react-native-toast-message";
 
-export const PrayerPartnerListItem = (props:{partner:PartnerListItem, onButtonPress?:(id:number, partner:PartnerListItem) => void}):JSX.Element => {
+export const PrayerPartnerListItem = (props:{partner:PartnerListItem, onButtonPress?:(id:number, partner:PartnerListItem) => void, onAltButtonPress?:(id:number, partner:PartnerListItem) => void}):JSX.Element => {
     
     const [leaveModalVisible, setLeaveModalVisible] = useState<boolean>(false);
+    const [reportModalVisible, setReportModalVisible] = useState<boolean>(false);
 
     const styles = StyleSheet.create({
         container: {
@@ -35,6 +36,12 @@ export const PrayerPartnerListItem = (props:{partner:PartnerListItem, onButtonPr
             textAlign: "center",
             color: COLORS.accent
         },
+        warningTextStyle: {
+            ...theme.text,
+            fontWeight: '700',
+            textAlign: "center",
+            color: COLORS.primary
+        },
         shareButtonView:{
             width: 100,
             borderRadius: 5,
@@ -42,8 +49,7 @@ export const PrayerPartnerListItem = (props:{partner:PartnerListItem, onButtonPr
         ShareButtonTopLevelView: {
             position: "absolute",
             right: 10,
-            justifyContent: "center",
-            alignSelf: "center"
+            flexDirection: "row",
         }
     });
 
@@ -55,14 +61,34 @@ export const PrayerPartnerListItem = (props:{partner:PartnerListItem, onButtonPr
                     <Text allowFontScaling={false} style={styles.nameText}>{props.partner.displayName}</Text>
                 </View>
                 <View style={styles.ShareButtonTopLevelView}>
-                    <TouchableOpacity 
-                        onPress={() => setLeaveModalVisible(true)}
-                    >  
-                        <View style={styles.shareButtonView}>
-                            <Text allowFontScaling={false} style={styles.textStyle}>Leave Partnership</Text>
-                        </View>
-                    </TouchableOpacity>
+                    <View>
+                        <ReportButton callback={() => setReportModalVisible(true)} buttonStyle={{ height: 40, width: 40}} buttonView={{justifyContent: "center", alignSelf: "center"}}/>
+                    </View>
+                    <View>
+                        <TouchableOpacity 
+                            onPress={() => setLeaveModalVisible(true)}
+                        >  
+                            <View style={styles.shareButtonView}>
+                                <Text allowFontScaling={false} style={styles.textStyle}>Leave Partnership</Text>
+                            </View>
+                        </TouchableOpacity>
+                    </View>
+
                 </View>
+                <Modal 
+                    visible={reportModalVisible}
+                    onRequestClose={() => setReportModalVisible(false)}
+                    animationType='slide'
+                    transparent={true}
+                >
+                    <Confirmation 
+                        callback={() => props.onAltButtonPress && props.onAltButtonPress(props.partner.userID, props.partner) && setReportModalVisible(false)}
+                        onCancel={() => setReportModalVisible(false)}
+                        promptText={'report this user? This action will end the partnership and send a report to our team for review. \n\nYou will be assigned a new partner.'}
+                        buttonText='Report'
+                        addPunctuation={false}
+                    />
+                </Modal>
                 <Modal 
                     visible={leaveModalVisible}
                     onRequestClose={() => setLeaveModalVisible(false)}

--- a/src/5-Content/ContentCard.tsx
+++ b/src/5-Content/ContentCard.tsx
@@ -9,18 +9,19 @@ import { makeDisplayText } from '../utilities/utilities';
 import { useAppSelector } from '../TypesAndInterfaces/hooks';
 import { RootState } from '../redux-store';
 import { ContentSourceEnum, extractYouTubeVideoId } from '../TypesAndInterfaces/config-sync/input-config-sync/content-field-config';
-import { BackButton, IconCounter } from '../widgets';
+import { BackButton, IconCounter, ReportButton } from '../widgets';
 import { ContentThumbnail } from './content-widgets';
 
 
 interface ContentCardProps {
   item:ContentListItem;
   onPress?:(id:number, item:ContentListItem) => void;
+  onAltButtonPress?:(id:number, item:ContentListItem) => void;
   style?:StyleProp<ViewStyle>;
   onKeywordPress?:(keyword:string) => void;
 }
 
-const ContentCard: React.FC<ContentCardProps> = ({ item, onPress, style, onKeywordPress }) => {
+const ContentCard: React.FC<ContentCardProps> = ({ item, onPress, style, onKeywordPress, onAltButtonPress }) => {
 
   const userID = useAppSelector((state: RootState) => state.account.userID);  
   const [showDescription, setShowDescription] = useState(false);
@@ -40,11 +41,16 @@ const ContentCard: React.FC<ContentCardProps> = ({ item, onPress, style, onKeywo
           <View style={styles.footerVertical}>
             <View style={styles.footerTitleRow}>
               <Text allowFontScaling={false} style={styles.contentCardTitle}>{item.title}</Text>
-              <IconCounter 
-                initialCount={item.likeCount}
-                ionsIconsName='thumbs-up-outline'
-                postURL={`${DOMAIN}/api/user/`+ userID + '/content/' + item.contentID + '/like'}
-              />
+
+              <View style={styles.footerButtonView}>
+              
+                <ReportButton callback={() => onAltButtonPress && onAltButtonPress(item.contentID, item)} buttonStyle={{ height: 25, width: 25}} buttonView={styles.reportButtonStyle}/>
+                <IconCounter 
+                  initialCount={item.likeCount}
+                  ionsIconsName='thumbs-up-outline'
+                  postURL={`${DOMAIN}/api/user/`+ userID + '/content/' + item.contentID + '/like'}
+                />
+              </View>
             </View>
             <View style={styles.footerDetailRow}>
               <Text allowFontScaling={false} style={styles.detailText} numberOfLines={1} ellipsizeMode='tail' >{makeDisplayText(item.source)}</Text>
@@ -156,7 +162,7 @@ const styles = StyleSheet.create({
   footerTitleRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'baseline',
+    alignItems: 'flex-start',
     padding: 0,
     paddingTop: 5,
   },
@@ -198,6 +204,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  footerButtonView: {
+    flexDirection: "column", 
+    alignSelf: "stretch"
+  },
+  reportButtonStyle: {
+    alignSelf: "center", 
+    justifyContent: "center", 
+    marginBottom: 5
+  }
 });
 
 export default ContentCard;

--- a/src/5-Content/ContentDisplay.tsx
+++ b/src/5-Content/ContentDisplay.tsx
@@ -1,8 +1,8 @@
 import axios, { AxiosError } from 'axios';
 import React, { useEffect, useState } from 'react';
-import { RootState } from '../redux-store';
+import { removeRecommendedContent, RootState } from '../redux-store';
 import { DOMAIN } from '@env';
-import { useAppSelector } from '../TypesAndInterfaces/hooks';
+import { useAppDispatch, useAppSelector } from '../TypesAndInterfaces/hooks';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ServerErrorResponse } from '../TypesAndInterfaces/config-sync/api-type-sync/utility-types';
 import ToastQueueManager from '../utilities/ToastQueueManager';
@@ -10,7 +10,10 @@ import { ContentListItem } from '../TypesAndInterfaces/config-sync/api-type-sync
 import { ContentSourceEnum, ContentTypeEnum, MOBILE_CONTENT_SUPPORTED_SOURCES } from '../TypesAndInterfaces/config-sync/input-config-sync/content-field-config';
 import SearchList from '../Widgets/SearchList/SearchList';
 import { SearchFilterIdentifiable, SearchListKey, SearchListValue } from '../Widgets/SearchList/searchList-types';
-import { ListItemTypesEnum, SearchType } from '../TypesAndInterfaces/config-sync/input-config-sync/search-config';
+import { DisplayItemType, ListItemTypesEnum, SearchType } from '../TypesAndInterfaces/config-sync/input-config-sync/search-config';
+import { Modal } from 'react-native';
+import { Confirmation } from '../widgets';
+import { set } from 'react-hook-form';
 
 
 /************************
@@ -25,6 +28,29 @@ const ContentDisplay = (props:{callback?:(() => void), navigation:NativeStackNav
     const userID:number = useAppSelector((state:RootState) => state.account.userID);
 
     const [contentList, setContentList] = useState<ContentListItem[]>([]); //Apply filtering locally
+    const [reportModalVisible, setReportModalVisible] = useState(false);
+    const [reportedContentID, setReportedContentID] = useState<number>(0);
+
+    const dispatch = useAppDispatch();
+
+    const RequestAccountHeader = {
+        headers: {
+          "jwt": jwt, 
+        }   
+    }
+
+    const reportContent = async () => {
+        await axios.post(`${DOMAIN}/api/content-archive/${reportedContentID}/report`, {}, RequestAccountHeader).then(() => {
+
+        setReportModalVisible(false);
+        setContentList(current => current.filter(content => content.contentID !== reportedContentID));
+        dispatch(removeRecommendedContent(reportedContentID));
+        
+        setReportedContentID(-1);
+        ToastQueueManager.show({message: 'Report received'})
+
+        }).catch((error:AxiosError<ServerErrorResponse>) => ToastQueueManager.show({error}));
+    }
 
     useEffect(() => {
         axios.get(`${DOMAIN}/api/user/`+ userID + '/content-list', { headers: { jwt }})
@@ -38,6 +64,7 @@ const ContentDisplay = (props:{callback?:(() => void), navigation:NativeStackNav
   
     
       return (
+        <React.Fragment>
         <SearchList
                 key='content-page'
                 name='content-page'
@@ -46,10 +73,25 @@ const ContentDisplay = (props:{callback?:(() => void), navigation:NativeStackNav
                 displayMap={new Map([
                         [
                             new SearchListKey({displayTitle:'Content', searchType: SearchType.CONTENT_ARCHIVE }),
-                            [...contentList].map((content) => new SearchListValue({displayType: ListItemTypesEnum.CONTENT_ARCHIVE, displayItem: content }))
+                            [...contentList].map((content) => new SearchListValue({displayType: ListItemTypesEnum.CONTENT_ARCHIVE, displayItem: content, onAlternativeButtonCallback: (id, item) => { setReportedContentID(id); setReportModalVisible(true); }}))
                         ],
                     ])}
             />
+            <Modal 
+                visible={reportModalVisible}
+                onRequestClose={() => setReportModalVisible(false)}
+                animationType='slide'
+                transparent={true}
+            >
+                <Confirmation 
+                    callback={() => reportContent()}
+                    onCancel={() => setReportModalVisible(false)}
+                    promptText={'report this content? This action will remove this content from your feed and send a report to our team for review.'}
+                    buttonText='Report'
+                    addPunctuation={false}
+                />
+            </Modal>
+        </React.Fragment>
       );
     };
     

--- a/src/5-Content/content-widgets.tsx
+++ b/src/5-Content/content-widgets.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useLayoutEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Image, StyleSheet, ImageStyle, ImageSourcePropType, Dimensions, TouchableOpacity } from 'react-native';
 import { ContentSourceEnum } from '../TypesAndInterfaces/config-sync/input-config-sync/content-field-config';
 
@@ -27,7 +27,7 @@ export const ContentThumbnail = (props:{imageUri:string|undefined, contentSource
         setAspectRatio(width / height);
     };
 
-    useLayoutEffect(() => {
+    useEffect(() => {
         let isMounted = true;
 
         const setImageAspect = (width:number, height:number) => {

--- a/src/Widgets/SearchList/SearchList.tsx
+++ b/src/Widgets/SearchList/SearchList.tsx
@@ -368,7 +368,7 @@ const SearchList = ({...props}:{key:any, name:string, defaultDisplayKey?:string,
                                 <LabelItem {...item} key={`label-${props.key}-${index}`} label={item.displayItem as LabelListItem} onPress={item.onPress} />
 
                             : item.displayType === ListItemTypesEnum.CONTENT_ARCHIVE ? 
-                                <ContentCard {...item} key={`content-${props.key}-${index}`} item={item.displayItem as ContentListItem} onPress={item.onPress} />
+                                <ContentCard {...item} key={`content-${props.key}-${index}`} item={item.displayItem as ContentListItem} onPress={item.onPress} onAltButtonPress={item.onAlternativeButtonCallback} />
 
                             : item.displayType === ListItemTypesEnum.PRAYER_REQUEST ? 
                                 <PrayerRequestTouchable {...item} key={`prayer-request-${props.key}-${index}`}
@@ -376,7 +376,7 @@ const SearchList = ({...props}:{key:any, name:string, defaultDisplayKey?:string,
 
                             : item.displayType === ListItemTypesEnum.PARTNER ? 
                                 <PrayerPartnerListItem {...item} key={`partner-${props.key}-${index}`}
-                                    partner={item.displayItem as PartnerListItem} onButtonPress={item.onPrimaryButtonCallback}
+                                    partner={item.displayItem as PartnerListItem} onButtonPress={item.onPrimaryButtonCallback} onAltButtonPress={item.onAlternativeButtonCallback}
                                 />
 
                             : item.displayType === ListItemTypesEnum.PENDING_PARTNER ? 

--- a/src/redux-store.tsx
+++ b/src/redux-store.tsx
@@ -74,6 +74,10 @@ const accountSlice = createSlice({
     setAnsweredPrayerRequestList: (state, action:PayloadAction<PrayerRequestListItem[]>) => state = {...state, answeredPrayerRequestList: action.payload},
     removeAnsweredPrayerRequest: (state, action:PayloadAction<number>) => state = removeListItem(state, action, 'answeredPrayerRequestList', 'prayerRequestID'),
     addAnsweredPrayerRequest: (state, action:PayloadAction<PrayerRequestListItem>) => state = addListItem(state, action, 'answeredPrayerRequestList'),
+    
+    // additional reducers for Dashboard page reporting
+    removeNewPrayerRequest: (state, action:PayloadAction<number>) => state = removeListItem(state, action, 'newPrayerRequestList', 'prayerRequestID'),
+    removeRecommendedContent: (state, action:PayloadAction<number>) => state = removeListItem(state, action, 'recommendedContentList', 'contentID'),
   },
 });
 
@@ -84,7 +88,7 @@ export const { setAccount, resetAccount, updateJWT, clearJWT, updateProfile, upd
       addPartner, removePartner, addPartnerPendingUser, removePartnerPendingUser, addPartnerPendingPartner, removePartnerPendingPartner, 
       setPartnerPendingPartners, setPartnerPendingUsers, setPartners, removeExpiringPrayerRequest, addOwnedPrayerRequest, 
       removeOwnedPrayerRequest, setOwnedPrayerRequests, addContact, removeContact, setContacts, 
-      setAnsweredPrayerRequestList, addAnsweredPrayerRequest, removeAnsweredPrayerRequest
+      setAnsweredPrayerRequestList, addAnsweredPrayerRequest, removeAnsweredPrayerRequest, removeNewPrayerRequest, removeRecommendedContent
     } = accountSlice.actions;
 
   export const saveJWTMiddleware:Middleware = store => next => action => {

--- a/src/widgets.tsx
+++ b/src/widgets.tsx
@@ -558,6 +558,39 @@ export const DeleteButton = (props:{callback:(() => void),  buttonView?:ViewStyl
     )
 }
 
+export const ReportButton = (props:{callback:(() => void), navigation?:NativeStackNavigationProp<any, string, undefined>, buttonView?:ViewStyle, buttonStyle?:ViewStyle, iconSize?:number}):JSX.Element => {
+    
+    const styles = StyleSheet.create({
+        reportButtonView: {
+            ...(props.buttonView ? props.buttonView : {position: "absolute", top: 1, right: 1}),
+        },
+        reportButton: {
+            ...(props.buttonStyle ? props.buttonStyle : {justifyContent: "center", alignItems: "center", height: 55, width: 55, borderRadius: 15}),
+            
+        }
+    })
+    
+    return (
+        <View style={styles.reportButtonView}>
+            <TouchableOpacity 
+                onPress={() => { 
+                    if(props.navigation) props.navigation.goBack();
+                    else if(props.callback) props.callback();
+                }}
+            >
+                <View style={styles.reportButton}>
+                    <Ionicons 
+                        name="flag-outline"
+                        color={COLORS.primary}
+                        size={props.iconSize ?? 30}
+                    />
+                </View>
+            </TouchableOpacity>
+
+        </View>
+    )
+}
+
 export const FolderButton = (props:{callback?:(() => void), buttonView?:ViewStyle}):JSX.Element => {
     const styles = StyleSheet.create({
         folderButton: {
@@ -608,7 +641,7 @@ export const Filler = (props:{fillerStyle?:ViewStyle}):JSX.Element => {
     )
 } 
 
-export const Confirmation = (props:{callback:(() => void), onCancel:(() => void), promptText:string, buttonText:string}):JSX.Element => {
+export const Confirmation = ({callback, onCancel, promptText, buttonText, addPunctuation = true}: {callback:(() => void), onCancel:(() => void), promptText:string, buttonText:string, addPunctuation?: boolean}):JSX.Element => {
     const styles = StyleSheet.create({
         deleteView: {
             backgroundColor: COLORS.black,
@@ -634,18 +667,17 @@ export const Confirmation = (props:{callback:(() => void), onCancel:(() => void)
     
     return (
         <SafeAreaView style={styles.deleteView}>
-            <Text allowFontScaling={false} style={styles.confirmDeleteText}>Are you sure you want to {props.promptText}?</Text>
+            <Text allowFontScaling={false} style={styles.confirmDeleteText}>Are you sure you want to {promptText}{addPunctuation ? '?' : ''}</Text>
             <View style={styles.buttons}>
                 <Raised_Button buttonStyle={styles.sign_in_button}
-                    text={props.buttonText}
-                    onPress={() => props.callback()}
+                    text={buttonText}
+                    onPress={() => callback()}
                 />
                 <Outline_Button 
                     text="Cancel"
-                    onPress={() => props.onCancel()}
+                    onPress={() => onCancel()}
                 />
             </View>
-            <Toast />
         </SafeAreaView>
     )
 }


### PR DESCRIPTION
Added reporting for prayer requests, users, comments, and content. 

- Created re-usable report widget
- Significant refactor to partnership page to align with partnership flow changes on server side
  - Note: left leave and accept routes for backwards compatibility in case an admin assigns "Pending Contract" manually
- extended some existing widgets above to allow multiple callbacks via searchlist for reporting or deleting
- No env changes

I had to make a few styling changes on the ContentCard. I found out through a day and a half of troubleshooting that `alignItems: 'baseline'` and `flexDirection: "column"` in a child view are incompatible, so I replaced baseline with 'flex-start'. it looks the same as it did before so it shouldn't break anything.

Let me know if you have additional questions